### PR TITLE
Add optional docId field to core models

### DIFF
--- a/lib/models/case.dart
+++ b/lib/models/case.dart
@@ -2,6 +2,7 @@
 import '../services/firebase_export.dart';
 
 class Case {
+  String? docId;
   final String caseNumber; // Unique identifier for the case
   final String caseName; // Name of the case
   final String courtName; // Name of the court handling the case
@@ -28,6 +29,7 @@ class Case {
       notificationId; // Unique notification ID for the case (changed to int)
 
   Case({
+    this.docId,
     required this.caseNumber,
     required this.caseName,
     required this.courtName,
@@ -54,8 +56,9 @@ class Case {
 
   });
 
-  factory Case.fromMap(Map<String, dynamic> map) {
+  factory Case.fromMap(Map<String, dynamic> map, {String? docId}) {
     return Case(
+      docId: docId,
       caseNumber: map['caseNumber'] as String,
       caseName: map['caseName'] as String,
       courtName: map['courtName'] as String,

--- a/lib/models/lawyer.dart
+++ b/lib/models/lawyer.dart
@@ -1,6 +1,7 @@
 import 'package:courtdiary/services/firebase_export.dart';
 
 class Lawyer {
+  String? docId;
   final String name;
   final String address;
   final String fcmToken;
@@ -12,6 +13,7 @@ class Lawyer {
   final DateTime subStartsAt;
 
   Lawyer({
+    this.docId,
     required this.name,
     required this.address,
     required this.fcmToken,
@@ -39,8 +41,9 @@ class Lawyer {
   }
 
   /// Create from Firestore Map
-  factory Lawyer.fromMap(Map<String, dynamic> map) {
+  factory Lawyer.fromMap(Map<String, dynamic> map, {String? docId}) {
     return Lawyer(
+      docId: docId,
       name: map['name'] ?? '',
       address: map['address'] ?? '',
       fcmToken: map['fcmToken'] ?? '',

--- a/lib/models/party.dart
+++ b/lib/models/party.dart
@@ -1,12 +1,13 @@
 class Party {
+  String? docId;
   final String name;
   final String phone;
   final String address;
   final String lawyerId;
 
-
   // Constructor
   Party({
+    this.docId,
     required this.name,
     required this.phone,
     required this.address,
@@ -25,15 +26,14 @@ class Party {
   }
 
   // Method to create a Party object from a Map (for example, when retrieving from a database)
-  factory Party.fromMap(Map<String, dynamic> map) {
+  factory Party.fromMap(Map<String, dynamic> map, {String? docId}) {
     Party party = Party(
+      docId: docId,
       name: map['name'],
       phone: map['phone'],
       address: map['address'],
       lawyerId: map['lawyerId'], // Extract the new field from the map
     );
-
-
 
     return party;
   }


### PR DESCRIPTION
## Summary
- add optional `docId` property to `Party`, `Case`, and `Lawyer` models for front-end reference
- allow `fromMap` factory constructors to accept document ID

## Testing
- `dart format lib/models/party.dart lib/models/case.dart lib/models/lawyer.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b702c3688330b6fce3196071872e