### PR TITLE
chore: update Android compile SDK

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,12 +16,13 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.appseba.courtdiary"
-    compileSdk = 34
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -60,4 +61,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 }


### PR DESCRIPTION
## Summary
- set compileSdk to 36 and enable core library desugaring
- add placeholder sounds directory referenced in pubspec

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c207922083308b6252b91c4a4b0c