### PR TITLE
feat(party): add party creation

### DIFF
--- a/lib/modules/party/controllers/add_party_controller.dart
+++ b/lib/modules/party/controllers/add_party_controller.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../services/party_service.dart';
+
+class AddPartyController extends GetxController {
+  final name = TextEditingController();
+  final phone = TextEditingController();
+  final address = TextEditingController();
+
+  final RxBool isLoading = false.obs;
+  final RxBool enableBtn = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    name.addListener(_validate);
+    phone.addListener(_validate);
+    address.addListener(_validate);
+  }
+
+  void _validate() {
+    enableBtn.value = name.text.trim().isNotEmpty &&
+        phone.text.trim().isNotEmpty &&
+        address.text.trim().isNotEmpty;
+  }
+
+  Future<void> addParty() async {
+    if (!enableBtn.value || isLoading.value) return;
+    try {
+      isLoading.value = true;
+      final user = AppFirebase().currentUser;
+      if (user == null) {
+        throw Exception('No authenticated user');
+      }
+
+      final party = Party(
+        name: name.text.trim(),
+        phone: phone.text.trim(),
+        address: address.text.trim(),
+        lawyerId: user.uid,
+      );
+
+      await PartyService.addParty(party);
+
+      Get.back();
+      Get.snackbar(
+        'সফল হয়েছে',
+        'পক্ষ যুক্ত করা হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.green,
+      );
+    } catch (e) {
+      Get.snackbar(
+        'ত্রুটি',
+        'পক্ষ যুক্ত করতে ব্যর্থ হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.red,
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    name.dispose();
+    phone.dispose();
+    address.dispose();
+    super.onClose();
+  }
+}
+

--- a/lib/modules/party/screens/party_screen.dart
+++ b/lib/modules/party/screens/party_screen.dart
@@ -1,10 +1,64 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_text_from_field.dart';
+import '../controllers/add_party_controller.dart';
 
 class PartyScreen extends StatelessWidget {
   const PartyScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    final controller = Get.put(AddPartyController());
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('নতুন পক্ষ যুক্ত করুন'),
+      ),
+      body: Obx(() {
+        return Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                spacing: 16,
+                children: [
+                  AppTextFromField(
+                    controller: controller.name,
+                    label: 'নাম',
+                    hintText: 'পক্ষের নাম লিখুন',
+                    prefixIcon: Icons.person,
+                  ),
+                  AppTextFromField(
+                    controller: controller.phone,
+                    label: 'মোবাইল',
+                    hintText: 'মোবাইল নম্বর লিখুন',
+                    prefixIcon: Icons.phone,
+                    keyboardType: TextInputType.phone,
+                  ),
+                  AppTextFromField(
+                    controller: controller.address,
+                    label: 'ঠিকানা',
+                    hintText: 'ঠিকানা লিখুন',
+                    prefixIcon: Icons.home,
+                    isMaxLines: 3,
+                  ),
+                  const SizedBox(height: 20),
+                  AppButton(
+                    label: 'সেভ করুন',
+                    onPressed: controller.enableBtn.value
+                        ? controller.addParty
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+            if (controller.isLoading.value)
+              const Center(child: CircularProgressIndicator()),
+          ],
+        );
+      }),
+    );
   }
 }
+

--- a/lib/modules/party/services/party_service.dart
+++ b/lib/modules/party/services/party_service.dart
@@ -1,0 +1,12 @@
+import '../../../constants/app_collections.dart';
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+
+class PartyService {
+  static final _firestore = AppFirebase().firestore;
+
+  static Future<void> addParty(Party party) async {
+    await _firestore.collection(AppCollections.parties).add(party.toMap());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add PartyService for Firestore CRUD
- create AddPartyController with form validation and submission
- build PartyScreen form to input and save party details

## Testing
- `dart format lib/modules/party/controllers/add_party_controller.dart lib/modules/party/services/party_service.dart lib/modules/party/screens/party_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ce36c8d083309da0fbe375edbea3