### PR TITLE
feat: add image picker for party profile

### DIFF
--- a/lib/modules/party/screens/add_party_screen.dart
+++ b/lib/modules/party/screens/add_party_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -23,6 +25,20 @@ class AddPartyScreen extends StatelessWidget {
               child: Column(
                 spacing: 16,
                 children: [
+                  GestureDetector(
+                    onTap: controller.showImagePicker,
+                    child: Obx(() {
+                      final image = controller.photo.value;
+                      return CircleAvatar(
+                        radius: 50,
+                        backgroundImage:
+                            image != null ? FileImage(File(image.path)) : null,
+                        child: image == null
+                            ? const Icon(Icons.camera_alt, size: 40)
+                            : null,
+                      );
+                    }),
+                  ),
                   AppTextFromField(
                     controller: controller.name,
                     label: 'নাম',

--- a/lib/modules/party/services/party_service.dart
+++ b/lib/modules/party/services/party_service.dart
@@ -1,12 +1,22 @@
+import 'dart:io';
+
 import '../../../constants/app_collections.dart';
 import '../../../models/party.dart';
 import '../../../services/app_firebase.dart';
 
 class PartyService {
   static final _firestore = AppFirebase().firestore;
+  static final _storage = AppFirebase().storage;
 
   static Future<void> addParty(Party party) async {
     await _firestore.collection(AppCollections.parties).add(party.toMap());
+  }
+
+  static Future<String> uploadPartyPhoto(File file, String userId) async {
+    final path = 'party_photos/$userId/${DateTime.now().millisecondsSinceEpoch}.jpg';
+    final ref = _storage.ref().child(path);
+    await ref.putFile(file);
+    return await ref.getDownloadURL();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,7 @@ dependencies:
   auth_buttons: ^3.0.3
   lottie: ^3.3.1
   dio: ^5.9.0
+  image_picker: ^1.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow selecting party profile photo via camera or gallery
- upload party image to Firebase Storage and store URL
- add image_picker dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d461aaa48330a8dfd16d95a3a5ac