### PR TITLE
refactor: nest parties under lawyer subcollection

### DIFF
--- a/lib/modules/party/services/party_service.dart
+++ b/lib/modules/party/services/party_service.dart
@@ -9,7 +9,11 @@ class PartyService {
   static final _storage = AppFirebase().storage;
 
   static Future<void> addParty(Party party) async {
-    await _firestore.collection(AppCollections.parties).add(party.toMap());
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(party.lawyerId)
+        .collection(AppCollections.parties)
+        .add(party.toMap());
   }
 
   static Future<String> uploadPartyPhoto(File file, String userId) async {
@@ -21,8 +25,9 @@ class PartyService {
 
   static Stream<List<Party>> getParties(String lawyerId) {
     return _firestore
+        .collection(AppCollections.lawyers)
+        .doc(lawyerId)
         .collection(AppCollections.parties)
-        .where('lawyerId', isEqualTo: lawyerId)
         .snapshots()
         .map((snapshot) => snapshot.docs
             .map((doc) => Party.fromMap(doc.data(), docId: doc.id))


### PR DESCRIPTION
## Summary
- refactor party service to store parties under each lawyer's `parties` subcollection
- query parties from lawyer subcollection instead of global collection

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/modules/party/services/party_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d89a65508330a0c43bf2118a0c58