### PR TITLE
Add party profile screen with update functionality

### DIFF
--- a/lib/modules/party/controllers/party_profile_controller.dart
+++ b/lib/modules/party/controllers/party_profile_controller.dart
@@ -1,0 +1,129 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../services/party_service.dart';
+
+class PartyProfileController extends GetxController {
+  final Party party;
+  PartyProfileController(this.party);
+
+  final name = TextEditingController();
+  final phone = TextEditingController();
+  final address = TextEditingController();
+
+  final Rx<XFile?> photo = Rx<XFile?>(null);
+  final ImagePicker _picker = ImagePicker();
+
+  final RxBool isLoading = false.obs;
+  final RxBool enableBtn = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    name.text = party.name;
+    phone.text = party.phone;
+    address.text = party.address;
+
+    name.addListener(_validate);
+    phone.addListener(_validate);
+    address.addListener(_validate);
+  }
+
+  void _validate() {
+    enableBtn.value = name.text.trim().isNotEmpty &&
+        phone.text.trim().isNotEmpty &&
+        address.text.trim().isNotEmpty;
+  }
+
+  void showImagePicker() {
+    Get.bottomSheet(
+      SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('গ্যালারি থেকে নির্বাচন করুন'),
+              onTap: () {
+                Get.back();
+                _pickImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('ক্যামেরা ব্যবহার করুন'),
+              onTap: () {
+                Get.back();
+                _pickImage(ImageSource.camera);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickImage(ImageSource source) async {
+    final picked = await _picker.pickImage(source: source, imageQuality: 80);
+    if (picked != null) {
+      photo.value = picked;
+    }
+  }
+
+  Future<void> updateParty() async {
+    if (!enableBtn.value || isLoading.value) return;
+    try {
+      isLoading.value = true;
+      final user = AppFirebase().currentUser;
+      if (user == null) {
+        throw Exception('No authenticated user');
+      }
+
+      String? photoUrl = party.photoUrl;
+      if (photo.value != null) {
+        photoUrl = await PartyService.uploadPartyPhoto(File(photo.value!.path), user.uid);
+      }
+
+      final updated = Party(
+        docId: party.docId,
+        name: name.text.trim(),
+        phone: phone.text.trim(),
+        address: address.text.trim(),
+        lawyerId: user.uid,
+        photoUrl: photoUrl,
+      );
+
+      await PartyService.updateParty(updated);
+
+      Get.back();
+      Get.snackbar(
+        'সফল হয়েছে',
+        'পক্ষ আপডেট করা হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.green,
+      );
+    } catch (e) {
+      Get.snackbar(
+        'ত্রুটি',
+        'পক্ষ আপডেট করতে ব্যর্থ হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.red,
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    name.dispose();
+    phone.dispose();
+    address.dispose();
+    photo.value = null;
+    super.onClose();
+  }
+}

--- a/lib/modules/party/screens/party_profile_screen.dart
+++ b/lib/modules/party/screens/party_profile_screen.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_text_from_field.dart';
+import '../controllers/party_profile_controller.dart';
+import '../../../models/party.dart';
+
+class PartyProfileScreen extends StatelessWidget {
+  final Party party;
+  const PartyProfileScreen({super.key, required this.party});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(PartyProfileController(party));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('পক্ষ প্রোফাইল'),
+      ),
+      body: Obx(() {
+        return Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                spacing: 16,
+                children: [
+                  GestureDetector(
+                    onTap: controller.showImagePicker,
+                    child: Obx(() {
+                      final image = controller.photo.value;
+                      return CircleAvatar(
+                        radius: 50,
+                        backgroundImage: image != null
+                            ? FileImage(File(image.path))
+                            : (party.photoUrl != null
+                                ? NetworkImage(party.photoUrl!) as ImageProvider
+                                : null),
+                        child: image == null && party.photoUrl == null
+                            ? const Icon(Icons.camera_alt, size: 40)
+                            : null,
+                      );
+                    }),
+                  ),
+                  AppTextFromField(
+                    controller: controller.name,
+                    label: 'নাম',
+                    hintText: 'পক্ষের নাম লিখুন',
+                    prefixIcon: Icons.person,
+                  ),
+                  AppTextFromField(
+                    controller: controller.phone,
+                    label: 'মোবাইল',
+                    hintText: 'মোবাইল নম্বর লিখুন',
+                    prefixIcon: Icons.phone,
+                    keyboardType: TextInputType.phone,
+                  ),
+                  AppTextFromField(
+                    controller: controller.address,
+                    label: 'ঠিকানা',
+                    hintText: 'ঠিকানা লিখুন',
+                    prefixIcon: Icons.home,
+                    isMaxLines: 3,
+                  ),
+                  const SizedBox(height: 20),
+                  AppButton(
+                    label: 'আপডেট করুন',
+                    onPressed: controller.enableBtn.value
+                        ? controller.updateParty
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+            if (controller.isLoading.value)
+              const Center(child: CircularProgressIndicator()),
+          ],
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/party/screens/party_screen.dart
+++ b/lib/modules/party/screens/party_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../controllers/party_controller.dart';
+import 'party_profile_screen.dart';
 
 class PartyScreen extends StatelessWidget {
   const PartyScreen({super.key});
@@ -26,6 +27,9 @@ class PartyScreen extends StatelessWidget {
                 : const CircleAvatar(child: Icon(Icons.person)),
             title: Text(party.name),
             subtitle: Text(party.phone),
+            onTap: () {
+              Get.to(() => PartyProfileScreen(party: party));
+            },
           );
         },
       );

--- a/lib/modules/party/services/party_service.dart
+++ b/lib/modules/party/services/party_service.dart
@@ -16,6 +16,19 @@ class PartyService {
         .add(party.toMap());
   }
 
+  static Future<void> updateParty(Party party) async {
+    if (party.docId == null) {
+      throw Exception('Party document ID is required for update');
+    }
+
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(party.lawyerId)
+        .collection(AppCollections.parties)
+        .doc(party.docId)
+        .update(party.toMap());
+  }
+
   static Future<String> uploadPartyPhoto(File file, String userId) async {
     final path = 'party_photos/$userId/${DateTime.now().millisecondsSinceEpoch}.jpg';
     final ref = _storage.ref().child(path);


### PR DESCRIPTION
## Summary
- add PartyService.updateParty for modifying existing party records
- implement PartyProfileController to manage editing party details
- create PartyProfileScreen and link from PartyScreen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd62ba688330b0c4e1c51b5b9002