### PR TITLE
feat: improve transaction forms with dropdowns

### DIFF
--- a/lib/modules/transaction/controllers/add_transaction_controller.dart
+++ b/lib/modules/transaction/controllers/add_transaction_controller.dart
@@ -6,9 +6,9 @@ import '../../../services/app_firebase.dart';
 import '../services/transaction_service.dart';
 
 class AddTransactionController extends GetxController {
-  final type = TextEditingController();
+  final RxnString type = RxnString();
   final amount = TextEditingController();
-  final paymentMethod = TextEditingController();
+  final RxnString paymentMethod = RxnString();
   final note = TextEditingController();
 
   final RxBool isLoading = false.obs;
@@ -17,15 +17,16 @@ class AddTransactionController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    type.addListener(_validate);
     amount.addListener(_validate);
-    paymentMethod.addListener(_validate);
+    ever(type, (_) => _validate());
+    ever(paymentMethod, (_) => _validate());
   }
 
   void _validate() {
-    enableBtn.value = type.text.trim().isNotEmpty &&
+    enableBtn.value =
+        type.value != null &&
         amount.text.trim().isNotEmpty &&
-        paymentMethod.text.trim().isNotEmpty;
+        paymentMethod.value != null;
   }
 
   Future<void> addTransaction() async {
@@ -38,10 +39,10 @@ class AddTransactionController extends GetxController {
       }
 
       final transaction = Transaction(
-        type: type.text.trim(),
+        type: type.value!,
         amount: double.tryParse(amount.text.trim()) ?? 0,
         note: note.text.trim().isEmpty ? null : note.text.trim(),
-        paymentMethod: paymentMethod.text.trim(),
+        paymentMethod: paymentMethod.value!,
         createdAt: DateTime.now(),
       );
 
@@ -68,9 +69,7 @@ class AddTransactionController extends GetxController {
 
   @override
   void onClose() {
-    type.dispose();
     amount.dispose();
-    paymentMethod.dispose();
     note.dispose();
     super.onClose();
   }

--- a/lib/modules/transaction/controllers/edit_transaction_controller.dart
+++ b/lib/modules/transaction/controllers/edit_transaction_controller.dart
@@ -9,9 +9,9 @@ class EditTransactionController extends GetxController {
   final Transaction transaction;
   EditTransactionController(this.transaction);
 
-  final type = TextEditingController();
+  final RxnString type = RxnString();
   final amount = TextEditingController();
-  final paymentMethod = TextEditingController();
+  final RxnString paymentMethod = RxnString();
   final note = TextEditingController();
 
   final RxBool isLoading = false.obs;
@@ -20,20 +20,21 @@ class EditTransactionController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    type.text = transaction.type;
+    type.value = transaction.type;
     amount.text = transaction.amount.toString();
-    paymentMethod.text = transaction.paymentMethod;
+    paymentMethod.value = transaction.paymentMethod;
     note.text = transaction.note ?? '';
 
-    type.addListener(_validate);
     amount.addListener(_validate);
-    paymentMethod.addListener(_validate);
+    ever(type, (_) => _validate());
+    ever(paymentMethod, (_) => _validate());
   }
 
   void _validate() {
-    enableBtn.value = type.text.trim().isNotEmpty &&
+    enableBtn.value =
+        type.value != null &&
         amount.text.trim().isNotEmpty &&
-        paymentMethod.text.trim().isNotEmpty;
+        paymentMethod.value != null;
   }
 
   Future<void> updateTransaction() async {
@@ -47,10 +48,10 @@ class EditTransactionController extends GetxController {
 
       final updated = Transaction(
         docId: transaction.docId,
-        type: type.text.trim(),
+        type: type.value!,
         amount: double.tryParse(amount.text.trim()) ?? 0,
         note: note.text.trim().isEmpty ? null : note.text.trim(),
-        paymentMethod: paymentMethod.text.trim(),
+        paymentMethod: paymentMethod.value!,
         createdAt: transaction.createdAt,
         partyId: transaction.partyId,
       );
@@ -78,9 +79,7 @@ class EditTransactionController extends GetxController {
 
   @override
   void onClose() {
-    type.dispose();
     amount.dispose();
-    paymentMethod.dispose();
     note.dispose();
     super.onClose();
   }

--- a/lib/modules/transaction/screens/add_transaction_screen.dart
+++ b/lib/modules/transaction/screens/add_transaction_screen.dart
@@ -3,6 +3,9 @@ import 'package:get/get.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
+import '../../../widgets/app_dropdown.dart';
+import '../../../utils/payment_methods.dart';
+import '../../../utils/transaction_types.dart';
 import '../controllers/add_transaction_controller.dart';
 
 class AddTransactionScreen extends StatelessWidget {
@@ -23,11 +26,13 @@ class AddTransactionScreen extends StatelessWidget {
               child: Column(
                 spacing: 16,
                 children: [
-                  AppTextFromField(
-                    controller: controller.type,
+                  AppDropdown(
+                    value: controller.type.value,
                     label: 'ধরণ',
-                    hintText: 'লেনদেনের ধরণ লিখুন',
+                    hintText: 'লেনদেনের ধরণ নির্বাচন করুন',
+                    items: getTransactionTypes(isTransaction: true),
                     prefixIcon: Icons.category,
+                    onChanged: (val) => controller.type.value = val,
                   ),
                   AppTextFromField(
                     controller: controller.amount,
@@ -36,11 +41,13 @@ class AddTransactionScreen extends StatelessWidget {
                     prefixIcon: Icons.money,
                     keyboardType: TextInputType.number,
                   ),
-                  AppTextFromField(
-                    controller: controller.paymentMethod,
+                  AppDropdown(
+                    value: controller.paymentMethod.value,
                     label: 'পেমেন্ট পদ্ধতি',
-                    hintText: 'পেমেন্ট পদ্ধতি লিখুন',
+                    hintText: 'পেমেন্ট পদ্ধতি নির্বাচন করুন',
+                    items: paymentMethods,
                     prefixIcon: Icons.payment,
+                    onChanged: (val) => controller.paymentMethod.value = val,
                   ),
                   AppTextFromField(
                     controller: controller.note,
@@ -49,13 +56,7 @@ class AddTransactionScreen extends StatelessWidget {
                     prefixIcon: Icons.note,
                     isMaxLines: 3,
                   ),
-                  const SizedBox(height: 20),
-                  AppButton(
-                    label: 'সেভ করুন',
-                    onPressed: controller.enableBtn.value
-                        ? controller.addTransaction
-                        : null,
-                  ),
+                  const SizedBox(height: 80),
                 ],
               ),
             ),
@@ -64,6 +65,16 @@ class AddTransactionScreen extends StatelessWidget {
           ],
         );
       }),
+      bottomNavigationBar: Obx(
+        () => Padding(
+          padding: const EdgeInsets.all(16),
+          child: AppButton(
+            label: 'সেভ করুন',
+            onPressed:
+                controller.enableBtn.value ? controller.addTransaction : null,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/modules/transaction/screens/edit_transaction_screen.dart
+++ b/lib/modules/transaction/screens/edit_transaction_screen.dart
@@ -3,6 +3,9 @@ import 'package:get/get.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
+import '../../../widgets/app_dropdown.dart';
+import '../../../utils/payment_methods.dart';
+import '../../../utils/transaction_types.dart';
 import '../controllers/edit_transaction_controller.dart';
 import '../../../models/transaction.dart';
 
@@ -25,11 +28,13 @@ class EditTransactionScreen extends StatelessWidget {
               child: Column(
                 spacing: 16,
                 children: [
-                  AppTextFromField(
-                    controller: controller.type,
+                  AppDropdown(
+                    value: controller.type.value,
                     label: 'ধরণ',
-                    hintText: 'লেনদেনের ধরণ লিখুন',
+                    hintText: 'লেনদেনের ধরণ নির্বাচন করুন',
+                    items: getTransactionTypes(isTransaction: true),
                     prefixIcon: Icons.category,
+                    onChanged: (val) => controller.type.value = val,
                   ),
                   AppTextFromField(
                     controller: controller.amount,
@@ -38,11 +43,13 @@ class EditTransactionScreen extends StatelessWidget {
                     prefixIcon: Icons.money,
                     keyboardType: TextInputType.number,
                   ),
-                  AppTextFromField(
-                    controller: controller.paymentMethod,
+                  AppDropdown(
+                    value: controller.paymentMethod.value,
                     label: 'পেমেন্ট পদ্ধতি',
-                    hintText: 'পেমেন্ট পদ্ধতি লিখুন',
+                    hintText: 'পেমেন্ট পদ্ধতি নির্বাচন করুন',
+                    items: paymentMethods,
                     prefixIcon: Icons.payment,
+                    onChanged: (val) => controller.paymentMethod.value = val,
                   ),
                   AppTextFromField(
                     controller: controller.note,
@@ -51,13 +58,7 @@ class EditTransactionScreen extends StatelessWidget {
                     prefixIcon: Icons.note,
                     isMaxLines: 3,
                   ),
-                  const SizedBox(height: 20),
-                  AppButton(
-                    label: 'আপডেট করুন',
-                    onPressed: controller.enableBtn.value
-                        ? controller.updateTransaction
-                        : null,
-                  ),
+                  const SizedBox(height: 80),
                 ],
               ),
             ),
@@ -66,6 +67,17 @@ class EditTransactionScreen extends StatelessWidget {
           ],
         );
       }),
+      bottomNavigationBar: Obx(
+        () => Padding(
+          padding: const EdgeInsets.all(16),
+          child: AppButton(
+            label: 'আপডেট করুন',
+            onPressed: controller.enableBtn.value
+                ? controller.updateTransaction
+                : null,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/app_dropdown.dart
+++ b/lib/widgets/app_dropdown.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../constants/app_colors.dart';
+import '../local_library/text_from_field_wraper.dart';
+
+class AppDropdown extends StatelessWidget {
+  final String? value;
+  final String label;
+  final String hintText;
+  final List<String> items;
+  final IconData prefixIcon;
+  final ValueChanged<String?> onChanged;
+
+  const AppDropdown({
+    super.key,
+    required this.value,
+    required this.label,
+    required this.hintText,
+    required this.items,
+    required this.prefixIcon,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormFieldWrapper(
+      borderFocusedColor: AppColors.fixedPrimary,
+      prefix: Icon(prefixIcon),
+      formField: DropdownButtonFormField<String>(
+        value: value,
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          labelText: label,
+          hintText: hintText,
+        ),
+        items: items
+            .map(
+              (item) => DropdownMenuItem<String>(
+                value: item,
+                child: Text(item),
+              ),
+            )
+            .toList(),
+        onChanged: onChanged,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- use centralized lists for payment methods and transaction types when adding or editing transactions
- move save/update actions to persistent bottom buttons
- add reusable dropdown form widget

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e60af0c883309932a14fd11ae50d