### PR TITLE
feat: add party profile view with edit and delete

### DIFF
--- a/lib/modules/party/controllers/edit_party_controller.dart
+++ b/lib/modules/party/controllers/edit_party_controller.dart
@@ -1,0 +1,129 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../services/party_service.dart';
+
+class EditPartyController extends GetxController {
+  final Party party;
+  EditPartyController(this.party);
+
+  final name = TextEditingController();
+  final phone = TextEditingController();
+  final address = TextEditingController();
+
+  final Rx<XFile?> photo = Rx<XFile?>(null);
+  final ImagePicker _picker = ImagePicker();
+
+  final RxBool isLoading = false.obs;
+  final RxBool enableBtn = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    name.text = party.name;
+    phone.text = party.phone;
+    address.text = party.address;
+
+    name.addListener(_validate);
+    phone.addListener(_validate);
+    address.addListener(_validate);
+  }
+
+  void _validate() {
+    enableBtn.value = name.text.trim().isNotEmpty &&
+        phone.text.trim().isNotEmpty &&
+        address.text.trim().isNotEmpty;
+  }
+
+  void showImagePicker() {
+    Get.bottomSheet(
+      SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('গ্যালারি থেকে নির্বাচন করুন'),
+              onTap: () {
+                Get.back();
+                _pickImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('ক্যামেরা ব্যবহার করুন'),
+              onTap: () {
+                Get.back();
+                _pickImage(ImageSource.camera);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickImage(ImageSource source) async {
+    final picked = await _picker.pickImage(source: source, imageQuality: 80);
+    if (picked != null) {
+      photo.value = picked;
+    }
+  }
+
+  Future<void> updateParty() async {
+    if (!enableBtn.value || isLoading.value) return;
+    try {
+      isLoading.value = true;
+      final user = AppFirebase().currentUser;
+      if (user == null) {
+        throw Exception('No authenticated user');
+      }
+
+      String? photoUrl = party.photoUrl;
+      if (photo.value != null) {
+        photoUrl = await PartyService.uploadPartyPhoto(File(photo.value!.path), user.uid);
+      }
+
+      final updated = Party(
+        docId: party.docId,
+        name: name.text.trim(),
+        phone: phone.text.trim(),
+        address: address.text.trim(),
+        lawyerId: user.uid,
+        photoUrl: photoUrl,
+      );
+
+      await PartyService.updateParty(updated);
+
+      Get.back();
+      Get.snackbar(
+        'সফল হয়েছে',
+        'পক্ষ আপডেট করা হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.green,
+      );
+    } catch (e) {
+      Get.snackbar(
+        'ত্রুটি',
+        'পক্ষ আপডেট করতে ব্যর্থ হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.red,
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    name.dispose();
+    phone.dispose();
+    address.dispose();
+    photo.value = null;
+    super.onClose();
+  }
+}

--- a/lib/modules/party/controllers/party_profile_controller.dart
+++ b/lib/modules/party/controllers/party_profile_controller.dart
@@ -1,129 +1,36 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:image_picker/image_picker.dart';
 
 import '../../../models/party.dart';
-import '../../../services/app_firebase.dart';
 import '../services/party_service.dart';
 
 class PartyProfileController extends GetxController {
   final Party party;
   PartyProfileController(this.party);
 
-  final name = TextEditingController();
-  final phone = TextEditingController();
-  final address = TextEditingController();
+  final RxBool isDeleting = false.obs;
 
-  final Rx<XFile?> photo = Rx<XFile?>(null);
-  final ImagePicker _picker = ImagePicker();
-
-  final RxBool isLoading = false.obs;
-  final RxBool enableBtn = false.obs;
-
-  @override
-  void onInit() {
-    super.onInit();
-    name.text = party.name;
-    phone.text = party.phone;
-    address.text = party.address;
-
-    name.addListener(_validate);
-    phone.addListener(_validate);
-    address.addListener(_validate);
-  }
-
-  void _validate() {
-    enableBtn.value = name.text.trim().isNotEmpty &&
-        phone.text.trim().isNotEmpty &&
-        address.text.trim().isNotEmpty;
-  }
-
-  void showImagePicker() {
-    Get.bottomSheet(
-      SafeArea(
-        child: Wrap(
-          children: [
-            ListTile(
-              leading: const Icon(Icons.photo_library),
-              title: const Text('গ্যালারি থেকে নির্বাচন করুন'),
-              onTap: () {
-                Get.back();
-                _pickImage(ImageSource.gallery);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.camera_alt),
-              title: const Text('ক্যামেরা ব্যবহার করুন'),
-              onTap: () {
-                Get.back();
-                _pickImage(ImageSource.camera);
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Future<void> _pickImage(ImageSource source) async {
-    final picked = await _picker.pickImage(source: source, imageQuality: 80);
-    if (picked != null) {
-      photo.value = picked;
-    }
-  }
-
-  Future<void> updateParty() async {
-    if (!enableBtn.value || isLoading.value) return;
+  Future<void> deleteParty() async {
+    if (isDeleting.value) return;
     try {
-      isLoading.value = true;
-      final user = AppFirebase().currentUser;
-      if (user == null) {
-        throw Exception('No authenticated user');
-      }
-
-      String? photoUrl = party.photoUrl;
-      if (photo.value != null) {
-        photoUrl = await PartyService.uploadPartyPhoto(File(photo.value!.path), user.uid);
-      }
-
-      final updated = Party(
-        docId: party.docId,
-        name: name.text.trim(),
-        phone: phone.text.trim(),
-        address: address.text.trim(),
-        lawyerId: user.uid,
-        photoUrl: photoUrl,
-      );
-
-      await PartyService.updateParty(updated);
-
+      isDeleting.value = true;
+      await PartyService.deleteParty(party);
       Get.back();
       Get.snackbar(
         'সফল হয়েছে',
-        'পক্ষ আপডেট করা হয়েছে',
+        'পক্ষ মুছে ফেলা হয়েছে',
         backgroundColor: Colors.white,
         colorText: Colors.green,
       );
     } catch (e) {
       Get.snackbar(
         'ত্রুটি',
-        'পক্ষ আপডেট করতে ব্যর্থ হয়েছে',
+        'পক্ষ মুছতে ব্যর্থ হয়েছে',
         backgroundColor: Colors.white,
         colorText: Colors.red,
       );
     } finally {
-      isLoading.value = false;
+      isDeleting.value = false;
     }
-  }
-
-  @override
-  void onClose() {
-    name.dispose();
-    phone.dispose();
-    address.dispose();
-    photo.value = null;
-    super.onClose();
   }
 }

--- a/lib/modules/party/screens/edit_party_screen.dart
+++ b/lib/modules/party/screens/edit_party_screen.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_text_from_field.dart';
+import '../controllers/edit_party_controller.dart';
+import '../../../models/party.dart';
+
+class EditPartyScreen extends StatelessWidget {
+  final Party party;
+  const EditPartyScreen({super.key, required this.party});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(EditPartyController(party));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('পক্ষ সম্পাদনা'),
+      ),
+      body: Obx(() {
+        return Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                spacing: 16,
+                children: [
+                  GestureDetector(
+                    onTap: controller.showImagePicker,
+                    child: Obx(() {
+                      final image = controller.photo.value;
+                      return CircleAvatar(
+                        radius: 50,
+                        backgroundImage: image != null
+                            ? FileImage(File(image.path))
+                            : (party.photoUrl != null
+                                ? NetworkImage(party.photoUrl!) as ImageProvider
+                                : null),
+                        child: image == null && party.photoUrl == null
+                            ? const Icon(Icons.camera_alt, size: 40)
+                            : null,
+                      );
+                    }),
+                  ),
+                  AppTextFromField(
+                    controller: controller.name,
+                    label: 'নাম',
+                    hintText: 'পক্ষের নাম লিখুন',
+                    prefixIcon: Icons.person,
+                  ),
+                  AppTextFromField(
+                    controller: controller.phone,
+                    label: 'মোবাইল',
+                    hintText: 'মোবাইল নম্বর লিখুন',
+                    prefixIcon: Icons.phone,
+                    keyboardType: TextInputType.phone,
+                  ),
+                  AppTextFromField(
+                    controller: controller.address,
+                    label: 'ঠিকানা',
+                    hintText: 'ঠিকানা লিখুন',
+                    prefixIcon: Icons.home,
+                    isMaxLines: 3,
+                  ),
+                  const SizedBox(height: 20),
+                  AppButton(
+                    label: 'আপডেট করুন',
+                    onPressed: controller.enableBtn.value
+                        ? controller.updateParty
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+            if (controller.isLoading.value)
+              const Center(child: CircularProgressIndicator()),
+          ],
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/party/screens/party_profile_screen.dart
+++ b/lib/modules/party/screens/party_profile_screen.dart
@@ -1,12 +1,11 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../../widgets/app_button.dart';
-import '../../../widgets/app_text_from_field.dart';
-import '../controllers/party_profile_controller.dart';
 import '../../../models/party.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_info_row.dart';
+import '../controllers/party_profile_controller.dart';
+import 'edit_party_screen.dart';
 
 class PartyProfileScreen extends StatelessWidget {
   final Party party;
@@ -22,59 +21,49 @@ class PartyProfileScreen extends StatelessWidget {
       body: Obx(() {
         return Stack(
           children: [
-            SingleChildScrollView(
+            Padding(
               padding: const EdgeInsets.all(16),
               child: Column(
                 spacing: 16,
                 children: [
-                  GestureDetector(
-                    onTap: controller.showImagePicker,
-                    child: Obx(() {
-                      final image = controller.photo.value;
-                      return CircleAvatar(
-                        radius: 50,
-                        backgroundImage: image != null
-                            ? FileImage(File(image.path))
-                            : (party.photoUrl != null
-                                ? NetworkImage(party.photoUrl!) as ImageProvider
-                                : null),
-                        child: image == null && party.photoUrl == null
-                            ? const Icon(Icons.camera_alt, size: 40)
-                            : null,
-                      );
-                    }),
-                  ),
-                  AppTextFromField(
-                    controller: controller.name,
-                    label: 'নাম',
-                    hintText: 'পক্ষের নাম লিখুন',
-                    prefixIcon: Icons.person,
-                  ),
-                  AppTextFromField(
-                    controller: controller.phone,
-                    label: 'মোবাইল',
-                    hintText: 'মোবাইল নম্বর লিখুন',
-                    prefixIcon: Icons.phone,
-                    keyboardType: TextInputType.phone,
-                  ),
-                  AppTextFromField(
-                    controller: controller.address,
-                    label: 'ঠিকানা',
-                    hintText: 'ঠিকানা লিখুন',
-                    prefixIcon: Icons.home,
-                    isMaxLines: 3,
-                  ),
-                  const SizedBox(height: 20),
-                  AppButton(
-                    label: 'আপডেট করুন',
-                    onPressed: controller.enableBtn.value
-                        ? controller.updateParty
+                  CircleAvatar(
+                    radius: 50,
+                    backgroundImage: party.photoUrl != null
+                        ? NetworkImage(party.photoUrl!)
                         : null,
+                    child: party.photoUrl == null
+                        ? const Icon(Icons.person, size: 40)
+                        : null,
+                  ),
+                  appInfoRow('নাম', party.name),
+                  appInfoRow('মোবাইল', party.phone),
+                  appInfoRow('ঠিকানা', party.address),
+                  const Spacer(),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: AppButton(
+                          label: 'এডিট',
+                          onPressed: () {
+                            Get.to(() => EditPartyScreen(party: party));
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: AppButton(
+                          label: 'ডিলিট',
+                          onPressed: controller.isDeleting.value
+                              ? null
+                              : controller.deleteParty,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
             ),
-            if (controller.isLoading.value)
+            if (controller.isDeleting.value)
               const Center(child: CircularProgressIndicator()),
           ],
         );

--- a/lib/modules/party/services/party_service.dart
+++ b/lib/modules/party/services/party_service.dart
@@ -46,5 +46,18 @@ class PartyService {
             .map((doc) => Party.fromMap(doc.data(), docId: doc.id))
             .toList());
   }
+
+  static Future<void> deleteParty(Party party) async {
+    if (party.docId == null) {
+      throw Exception('Party document ID is required for delete');
+    }
+
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(party.lawyerId)
+        .collection(AppCollections.parties)
+        .doc(party.docId)
+        .delete();
+  }
 }
 


### PR DESCRIPTION
## Summary
- add party profile screen with edit and delete actions
- move edit form to dedicated screen and controller
- support removing a party via PartyService

## Testing
- `dart format lib/modules/party/screens/party_profile_screen.dart lib/modules/party/controllers/party_profile_controller.dart lib/modules/party/screens/edit_party_screen.dart lib/modules/party/controllers/edit_party_controller.dart lib/modules/party/services/party_service.dart` (fail: command not found)
- `flutter analyze` (fail: command not found)
- `flutter test` (fail: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b1ebfd1b548330b3d33583f67ab477