### PR TITLE
feat: improve transaction listing

### DIFF
--- a/lib/modules/accounts/screens/accounts_screen.dart
+++ b/lib/modules/accounts/screens/accounts_screen.dart
@@ -1,7 +1,12 @@
 import 'package:courtdiary/widgets/data_not_found.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+
+import '../../../services/app_firebase.dart';
 import '../controllers/transaction_controller.dart';
+import '../services/transaction_service.dart';
+import '../widgets/transaction_tile.dart';
+import 'all_transactions_screen.dart';
 import 'edit_transaction_screen.dart';
 
 class AccountsScreen extends StatelessWidget {
@@ -14,22 +19,53 @@ class AccountsScreen extends StatelessWidget {
       if (controller.isLoading.value) {
         return const Center(child: CircularProgressIndicator());
       }
-      if (controller.transactions.isEmpty) {
-        return const DataNotFound(
-            title: "Sorry", subtitle: 'No Transaction Found');
-      }
-      return ListView.builder(
-        itemCount: controller.transactions.length,
-        itemBuilder: (context, index) {
-          final transaction = controller.transactions[index];
-          return ListTile(
-            title: Text('${transaction.type} - ${transaction.amount}'),
-            subtitle: Text(transaction.paymentMethod),
-            onTap: () {
-              Get.to(() => EditTransactionScreen(transaction: transaction));
-            },
-          );
-        },
+      return Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Recent Transactions',
+                    style:
+                        TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                TextButton(
+                  onPressed: () {
+                    Get.to(() => AllTransactionsScreen());
+                  },
+                  child: const Text('All Transactions'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: controller.transactions.isEmpty
+                ? const DataNotFound(
+                    title: 'Sorry', subtitle: 'No Transaction Found')
+                : ListView.builder(
+                    itemCount: controller.transactions.length > 10
+                        ? 10
+                        : controller.transactions.length,
+                    itemBuilder: (context, index) {
+                      final transaction = controller.transactions[index];
+                      return TransactionTile(
+                        transaction: transaction,
+                        onEdit: () {
+                          Get.to(() =>
+                              EditTransactionScreen(transaction: transaction));
+                        },
+                        onDelete: () async {
+                          final user = AppFirebase().currentUser;
+                          if (user != null && transaction.docId != null) {
+                            await TransactionService.deleteTransaction(
+                                transaction.docId!, user.uid);
+                          }
+                        },
+                      );
+                    },
+                  ),
+          ),
+        ],
       );
     });
   }

--- a/lib/modules/accounts/screens/all_transactions_screen.dart
+++ b/lib/modules/accounts/screens/all_transactions_screen.dart
@@ -1,0 +1,120 @@
+import 'package:courtdiary/widgets/data_not_found.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../services/app_firebase.dart';
+import '../../../utils/transaction_types.dart';
+import '../controllers/transaction_controller.dart';
+import '../services/transaction_service.dart';
+import '../widgets/transaction_tile.dart';
+import 'edit_transaction_screen.dart';
+
+class AllTransactionsScreen extends StatelessWidget {
+  AllTransactionsScreen({super.key});
+
+  final controller = Get.find<TransactionController>();
+  final RxString typeFilter = 'All'.obs;
+  final RxString dateFilter = 'All'.obs;
+
+  @override
+  Widget build(BuildContext context) {
+    final types = ['All', ...getTransactionTypes()];
+    final dates = ['All', 'Today', 'This Week', 'This Month'];
+    return Scaffold(
+      appBar: AppBar(title: const Text('All Transactions')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Obx(
+                    () => DropdownButtonFormField<String>(
+                      value: typeFilter.value,
+                      decoration: const InputDecoration(labelText: 'Type'),
+                      items: types
+                          .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                          .toList(),
+                      onChanged: (v) => typeFilter.value = v ?? 'All',
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Obx(
+                    () => DropdownButtonFormField<String>(
+                      value: dateFilter.value,
+                      decoration: const InputDecoration(labelText: 'Date'),
+                      items: dates
+                          .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                          .toList(),
+                      onChanged: (v) => dateFilter.value = v ?? 'All',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Obx(() {
+              final filtered = controller.transactions.where((t) {
+                final now = DateTime.now();
+                bool typeMatch =
+                    typeFilter.value == 'All' || t.type == typeFilter.value;
+                bool dateMatch = true;
+                switch (dateFilter.value) {
+                  case 'Today':
+                    dateMatch = t.createdAt.year == now.year &&
+                        t.createdAt.month == now.month &&
+                        t.createdAt.day == now.day;
+                    break;
+                  case 'This Week':
+                    final start = now.subtract(Duration(days: now.weekday - 1));
+                    final end = start.add(const Duration(days: 7));
+                    dateMatch = t.createdAt.isAfter(start) &&
+                        t.createdAt.isBefore(end);
+                    break;
+                  case 'This Month':
+                    dateMatch = t.createdAt.year == now.year &&
+                        t.createdAt.month == now.month;
+                    break;
+                  default:
+                    dateMatch = true;
+                }
+                return typeMatch && dateMatch;
+              }).toList();
+
+              if (filtered.isEmpty) {
+                return const DataNotFound(
+                    title: 'Sorry', subtitle: 'No Transaction Found');
+              }
+
+              return ListView.builder(
+                itemCount: filtered.length,
+                itemBuilder: (context, index) {
+                  final transaction = filtered[index];
+                  return TransactionTile(
+                    transaction: transaction,
+                    onEdit: () {
+                      Get.to(() =>
+                          EditTransactionScreen(transaction: transaction));
+                    },
+                    onDelete: () async {
+                      final user = AppFirebase().currentUser;
+                      if (user != null && transaction.docId != null) {
+                        await TransactionService.deleteTransaction(
+                            transaction.docId!, user.uid);
+                      }
+                    },
+                  );
+                },
+              );
+            }),
+          )
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/modules/accounts/services/transaction_service.dart
+++ b/lib/modules/accounts/services/transaction_service.dart
@@ -38,4 +38,13 @@ class TransactionService {
             .map((doc) => Transaction.fromMap(doc.data(), docId: doc.id))
             .toList());
   }
+
+  static Future<void> deleteTransaction(String docId, String userId) async {
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(userId)
+        .collection(AppCollections.transactions)
+        .doc(docId)
+        .delete();
+  }
 }

--- a/lib/modules/accounts/widgets/transaction_tile.dart
+++ b/lib/modules/accounts/widgets/transaction_tile.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../models/transaction.dart';
+
+class TransactionTile extends StatelessWidget {
+  final Transaction transaction;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  const TransactionTile({
+    super.key,
+    required this.transaction,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  IconData _iconForType(String type) {
+    switch (type) {
+      case 'Expense':
+        return Icons.remove_circle_outline;
+      case 'Deposit':
+        return Icons.add_circle_outline;
+      case 'Capital Withdrawal':
+        return Icons.account_balance_wallet_outlined;
+      case 'Money Transfer':
+        return Icons.swap_horiz;
+      default:
+        return Icons.attach_money;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(_iconForType(transaction.type)),
+      title: Text('${transaction.type} - ${transaction.amount}'),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(DateFormat('dd MMM yyyy').format(transaction.createdAt)),
+          Text('Payment: ${transaction.paymentMethod}'),
+          if (transaction.note != null && transaction.note!.isNotEmpty)
+            Text(transaction.note!),
+        ],
+      ),
+      trailing: PopupMenuButton<String>(
+        onSelected: (value) {
+          if (value == 'edit') {
+            onEdit();
+          } else if (value == 'delete') {
+            onDelete();
+          }
+        },
+        itemBuilder: (context) => const [
+          PopupMenuItem(value: 'edit', child: Text('Edit')),
+          PopupMenuItem(value: 'delete', child: Text('Delete')),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable TransactionTile widget with icons and menus
- show recent transactions with link to full list
- implement full transactions screen with filtering options
- allow deleting transactions through service

## Testing
- `dart format lib/modules/accounts/screens/accounts_screen.dart lib/modules/accounts/screens/all_transactions_screen.dart lib/modules/accounts/widgets/transaction_tile.dart lib/modules/accounts/services/transaction_service.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b1f36b7e70833080a349b31c23e030