### PR TITLE
feat: add party tile widget

### DIFF
--- a/lib/modules/party/screens/party_screen.dart
+++ b/lib/modules/party/screens/party_screen.dart
@@ -1,4 +1,5 @@
 import 'package:courtdiary/widgets/data_not_found.dart';
+import 'package:courtdiary/widgets/party_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -22,12 +23,8 @@ class PartyScreen extends StatelessWidget {
         itemCount: controller.parties.length,
         itemBuilder: (context, index) {
           final party = controller.parties[index];
-          return ListTile(
-            leading: party.photoUrl != null
-                ? CircleAvatar(backgroundImage: NetworkImage(party.photoUrl!))
-                : const CircleAvatar(child: Icon(Icons.person)),
-            title: Text(party.name),
-            subtitle: Text(party.phone),
+          return PartyTile(
+            party: party,
             onTap: () {
               Get.to(() => PartyProfileScreen(party: party));
             },

--- a/lib/widgets/party_tile.dart
+++ b/lib/widgets/party_tile.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:courtdiary/models/party.dart';
+
+class PartyTile extends StatelessWidget {
+  final Party party;
+  final VoidCallback? onTap;
+
+  const PartyTile({super.key, required this.party, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: party.photoUrl != null
+            ? CircleAvatar(backgroundImage: NetworkImage(party.photoUrl!))
+            : const CircleAvatar(child: Icon(Icons.person)),
+        title: Text(party.name),
+        subtitle: Text(party.phone),
+        trailing: const Icon(Icons.arrow_forward_ios),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable `PartyTile` widget with party photo, name, phone and trailing arrow
- use `PartyTile` in `PartyScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6b363c48330abb3a1d59fb310be