### PR TITLE
feat: add case management module

### DIFF
--- a/lib/modules/case/controllers/add_case_controller.dart
+++ b/lib/modules/case/controllers/add_case_controller.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/case.dart';
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../../../services/firebase_export.dart';
+import '../../party/services/party_service.dart';
+import '../services/case_service.dart';
+
+class AddCaseController extends GetxController {
+  final caseNumber = TextEditingController();
+  final caseName = TextEditingController();
+  final plaintiffName = TextEditingController();
+  final defendantName = TextEditingController();
+  final underSection = TextEditingController();
+  final nextAction = TextEditingController();
+  final previousAction = TextEditingController();
+  final casePriority = TextEditingController();
+  final caseOutcome = TextEditingController();
+  final caseStatus = TextEditingController();
+  final partyType = TextEditingController();
+
+  final Rx<DateTime?> nextDate = Rx<DateTime?>(null);
+  final Rx<DateTime?> previousDate = Rx<DateTime?>(null);
+
+  final Rx<Party?> selectedParty = Rx<Party?>(null);
+  final RxString selectedCourt = ''.obs;
+
+  final RxList<Party> parties = <Party>[].obs;
+  final RxList<String> courts = <String>[].obs;
+
+  final RxBool isLoading = false.obs;
+  final RxBool enableBtn = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadParties();
+    _loadCourts();
+    caseNumber.addListener(validate);
+    caseName.addListener(validate);
+  }
+  void validate() {
+    enableBtn.value = caseNumber.text.trim().isNotEmpty &&
+        caseName.text.trim().isNotEmpty &&
+        selectedParty.value != null &&
+        selectedCourt.value.isNotEmpty;
+  }
+
+  void _loadParties() {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    PartyService.getParties(user.uid).listen((data) {
+      parties.value = data;
+    });
+  }
+
+  Future<void> _loadCourts() async {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    final doc = await AppFirebase()
+        .firestore
+        .collection('lawyers')
+        .doc(user.uid)
+        .get();
+    final list = List<String>.from(doc.data()?['courts'] ?? []);
+    courts.value = list;
+  }
+
+  Future<void> addCase() async {
+    if (!enableBtn.value || isLoading.value) return;
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    try {
+      isLoading.value = true;
+      final party = selectedParty.value!;
+      final c = Case(
+        caseNumber: caseNumber.text.trim(),
+        caseName: caseName.text.trim(),
+        courtName: selectedCourt.value,
+        partyName: party.name,
+        partyNumber: party.phone,
+        partyId: party.docId!,
+        lawyerId: user.uid,
+        isNotify: false,
+        isSendSms: false,
+        plaintiffName: plaintiffName.text.trim(),
+        defendantName: defendantName.text.trim(),
+        underSection: underSection.text.trim(),
+        nextDate: Timestamp.fromDate(nextDate.value ?? DateTime.now()),
+        previousDate: Timestamp.fromDate(previousDate.value ?? DateTime.now()),
+        nextAction: nextAction.text.trim(),
+        previousAction: previousAction.text.trim(),
+        casePriority: casePriority.text.trim(),
+        caseOutcome: caseOutcome.text.trim(),
+        lastUpdated: Timestamp.now(),
+        createdAt: Timestamp.now(),
+        caseStatus: caseStatus.text.trim(),
+        partyType: partyType.text.trim(),
+        notificationId: 0,
+      );
+      await CaseService.addCase(c);
+      Get.back();
+      Get.snackbar('Success', 'Case added');
+    } catch (e) {
+      Get.snackbar('Error', 'Failed to add case');
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    caseNumber.dispose();
+    caseName.dispose();
+    plaintiffName.dispose();
+    defendantName.dispose();
+    underSection.dispose();
+    nextAction.dispose();
+    previousAction.dispose();
+    casePriority.dispose();
+    caseOutcome.dispose();
+    caseStatus.dispose();
+    partyType.dispose();
+    super.onClose();
+  }
+}

--- a/lib/modules/case/controllers/case_controller.dart
+++ b/lib/modules/case/controllers/case_controller.dart
@@ -1,0 +1,46 @@
+import 'package:get/get.dart';
+
+import '../../../models/case.dart';
+import '../../../services/app_firebase.dart';
+import '../services/case_service.dart';
+
+class CaseController extends GetxController {
+  final RxList<Case> cases = <Case>[].obs;
+  final RxBool isLoading = true.obs;
+  DateTime? filterDate;
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadTodayCases();
+  }
+
+  void loadTodayCases() {
+    final user = AppFirebase().currentUser;
+    if (user == null) {
+      isLoading.value = false;
+      return;
+    }
+    CaseService.getCases(user.uid, date: DateTime.now()).listen((data) {
+      cases.value = data;
+      isLoading.value = false;
+    });
+  }
+
+  void loadAllCases({DateTime? date}) {
+    final user = AppFirebase().currentUser;
+    if (user == null) {
+      isLoading.value = false;
+      return;
+    }
+    isLoading.value = true;
+    CaseService.getCases(user.uid, date: date).listen((data) {
+      cases.value = data;
+      isLoading.value = false;
+    });
+  }
+
+  Future<void> deleteCase(Case c) async {
+    await CaseService.deleteCase(c);
+  }
+}

--- a/lib/modules/case/controllers/edit_case_controller.dart
+++ b/lib/modules/case/controllers/edit_case_controller.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/case.dart';
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../../../services/firebase_export.dart';
+import '../../party/services/party_service.dart';
+import '../services/case_service.dart';
+
+class EditCaseController extends GetxController {
+  EditCaseController(this.caseData);
+
+  final Case caseData;
+
+  final caseNumber = TextEditingController();
+  final caseName = TextEditingController();
+  final plaintiffName = TextEditingController();
+  final defendantName = TextEditingController();
+  final underSection = TextEditingController();
+  final nextAction = TextEditingController();
+  final previousAction = TextEditingController();
+  final casePriority = TextEditingController();
+  final caseOutcome = TextEditingController();
+  final caseStatus = TextEditingController();
+  final partyType = TextEditingController();
+
+  final Rx<DateTime?> nextDate = Rx<DateTime?>(null);
+  final Rx<DateTime?> previousDate = Rx<DateTime?>(null);
+
+  final Rx<Party?> selectedParty = Rx<Party?>(null);
+  final RxString selectedCourt = ''.obs;
+
+  final RxList<Party> parties = <Party>[].obs;
+  final RxList<String> courts = <String>[].obs;
+
+  final RxBool isLoading = false.obs;
+  final RxBool enableBtn = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadParties();
+    _loadCourts();
+    _fillData();
+    caseNumber.addListener(validate);
+    caseName.addListener(validate);
+  }
+
+  void _fillData() {
+    caseNumber.text = caseData.caseNumber;
+    caseName.text = caseData.caseName;
+    plaintiffName.text = caseData.plaintiffName;
+    defendantName.text = caseData.defendantName;
+    underSection.text = caseData.underSection;
+    nextAction.text = caseData.nextAction;
+    previousAction.text = caseData.previousAction;
+    casePriority.text = caseData.casePriority;
+    caseOutcome.text = caseData.caseOutcome;
+    caseStatus.text = caseData.caseStatus;
+    partyType.text = caseData.partyType;
+    nextDate.value = caseData.nextDate.toDate();
+    previousDate.value = caseData.previousDate.toDate();
+    selectedCourt.value = caseData.courtName;
+  }
+
+  void validate() {
+    enableBtn.value = caseNumber.text.trim().isNotEmpty &&
+        caseName.text.trim().isNotEmpty &&
+        selectedParty.value != null &&
+        selectedCourt.value.isNotEmpty;
+  }
+
+  void _loadParties() {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    PartyService.getParties(user.uid).listen((data) {
+      parties.value = data;
+      selectedParty.value = data.firstWhereOrNull((p) => p.docId == caseData.partyId);
+    });
+  }
+
+  Future<void> _loadCourts() async {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    final doc = await AppFirebase()
+        .firestore
+        .collection('lawyers')
+        .doc(user.uid)
+        .get();
+    courts.value = List<String>.from(doc.data()?['courts'] ?? []);
+  }
+
+  Future<void> updateCase() async {
+    if (!enableBtn.value || isLoading.value) return;
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    try {
+      isLoading.value = true;
+      final party = selectedParty.value!;
+      final c = Case(
+        docId: caseData.docId,
+        caseNumber: caseNumber.text.trim(),
+        caseName: caseName.text.trim(),
+        courtName: selectedCourt.value,
+        partyName: party.name,
+        partyNumber: party.phone,
+        partyId: party.docId!,
+        lawyerId: user.uid,
+        isNotify: caseData.isNotify,
+        isSendSms: caseData.isSendSms,
+        plaintiffName: plaintiffName.text.trim(),
+        defendantName: defendantName.text.trim(),
+        underSection: underSection.text.trim(),
+        nextDate: Timestamp.fromDate(nextDate.value ?? DateTime.now()),
+        previousDate: Timestamp.fromDate(previousDate.value ?? DateTime.now()),
+        nextAction: nextAction.text.trim(),
+        previousAction: previousAction.text.trim(),
+        casePriority: casePriority.text.trim(),
+        caseOutcome: caseOutcome.text.trim(),
+        lastUpdated: Timestamp.now(),
+        createdAt: caseData.createdAt,
+        caseStatus: caseStatus.text.trim(),
+        partyType: partyType.text.trim(),
+        notificationId: caseData.notificationId,
+      );
+      await CaseService.updateCase(c);
+      Get.back();
+      Get.snackbar('Success', 'Case updated');
+    } catch (e) {
+      Get.snackbar('Error', 'Failed to update case');
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    caseNumber.dispose();
+    caseName.dispose();
+    plaintiffName.dispose();
+    defendantName.dispose();
+    underSection.dispose();
+    nextAction.dispose();
+    previousAction.dispose();
+    casePriority.dispose();
+    caseOutcome.dispose();
+    caseStatus.dispose();
+    partyType.dispose();
+    super.onClose();
+  }
+}

--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_text_from_field.dart';
+import '../../../models/party.dart';
+import '../controllers/add_case_controller.dart';
+
+class AddCaseScreen extends StatelessWidget {
+  const AddCaseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(AddCaseController());
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Case')),
+      body: Obx(() {
+        return Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                spacing: 16,
+                children: [
+                  AppTextFromField(
+                    controller: controller.caseNumber,
+                    label: 'Case Number',
+                    hintText: 'Enter case number',
+                  ),
+                  AppTextFromField(
+                    controller: controller.caseName,
+                    label: 'Case Name',
+                    hintText: 'Enter case name',
+                  ),
+                  DropdownButtonFormField<Party>(
+                    value: controller.selectedParty.value,
+                    decoration: const InputDecoration(labelText: 'Party'),
+                    items: controller.parties
+                        .map((p) => DropdownMenuItem(
+                              value: p,
+                              child: Text(p.name),
+                            ))
+                        .toList(),
+                    onChanged: (p) {
+                      controller.selectedParty.value = p;
+                      controller.validate();
+                    },
+                  ),
+                  DropdownButtonFormField<String>(
+                    value: controller.selectedCourt.value.isEmpty
+                        ? null
+                        : controller.selectedCourt.value,
+                    decoration: const InputDecoration(labelText: 'Court'),
+                    items: controller.courts
+                        .map((s) => DropdownMenuItem(
+                              value: s,
+                              child: Text(s),
+                            ))
+                        .toList(),
+                    onChanged: (v) {
+                      controller.selectedCourt.value = v ?? '';
+                      controller.validate();
+                    },
+                  ),
+                  AppTextFromField(
+                    controller: controller.plaintiffName,
+                    label: 'Plaintiff',
+                  ),
+                  AppTextFromField(
+                    controller: controller.defendantName,
+                    label: 'Defendant',
+                  ),
+                  AppButton(
+                    label: 'Save',
+                    onPressed: controller.enableBtn.value
+                        ? controller.addCase
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+            if (controller.isLoading.value)
+              const Center(child: CircularProgressIndicator()),
+          ],
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/case/screens/case_list_screen.dart
+++ b/lib/modules/case/screens/case_list_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/case_tile.dart';
+import '../../../widgets/data_not_found.dart';
+import '../controllers/case_controller.dart';
+import 'case_profile_screen.dart';
+import 'edit_case_screen.dart';
+
+class CaseListScreen extends StatefulWidget {
+  const CaseListScreen({super.key});
+
+  @override
+  State<CaseListScreen> createState() => _CaseListScreenState();
+}
+
+class _CaseListScreenState extends State<CaseListScreen> {
+  final controller = Get.put(CaseController());
+  DateTime? selectedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    controller.loadAllCases();
+  }
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      firstDate: DateTime(now.year - 5),
+      lastDate: DateTime(now.year + 5),
+      initialDate: selectedDate ?? now,
+    );
+    if (date != null) {
+      setState(() => selectedDate = date);
+      controller.loadAllCases(date: date);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('All Cases'),
+        actions: [
+          IconButton(onPressed: _pickDate, icon: const Icon(Icons.filter_alt))
+        ],
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.cases.isEmpty) {
+          return const DataNotFound(title: 'Sorry', subtitle: 'No Case Found');
+        }
+        return ListView.builder(
+          itemCount: controller.cases.length,
+          itemBuilder: (context, index) {
+            final c = controller.cases[index];
+            return CaseTile(
+              data: c,
+              onTap: () => Get.to(() => CaseProfileScreen(caseData: c)),
+              onEdit: () => Get.to(() => EditCaseScreen(caseData: c)),
+              onDelete: () => controller.deleteCase(c),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/case/screens/case_profile_screen.dart
+++ b/lib/modules/case/screens/case_profile_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/case.dart';
+import '../controllers/case_controller.dart';
+import 'edit_case_screen.dart';
+
+class CaseProfileScreen extends StatelessWidget {
+  final Case caseData;
+  const CaseProfileScreen({super.key, required this.caseData});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CaseController>();
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(caseData.caseName),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: () => Get.to(() => EditCaseScreen(caseData: caseData)),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            onPressed: () {
+              controller.deleteCase(caseData);
+              Get.back();
+            },
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            _row('Case Number', caseData.caseNumber),
+            _row('Court', caseData.courtName),
+            _row('Party', caseData.partyName),
+            _row('Plaintiff', caseData.plaintiffName),
+            _row('Defendant', caseData.defendantName),
+            _row('Next Date', caseData.nextDate.toDate().toString()),
+            _row('Previous Date', caseData.previousDate.toDate().toString()),
+            _row('Next Action', caseData.nextAction),
+            _row('Previous Action', caseData.previousAction),
+            _row('Status', caseData.caseStatus),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _row(String title, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Expanded(flex: 2, child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold))),
+          Expanded(flex: 3, child: Text(value)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/modules/case/screens/case_screen.dart
+++ b/lib/modules/case/screens/case_screen.dart
@@ -1,10 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/data_not_found.dart';
+import '../../../widgets/case_tile.dart';
+import '../controllers/case_controller.dart';
+import 'case_list_screen.dart';
+import 'case_profile_screen.dart';
+import 'edit_case_screen.dart';
 
 class CaseScreen extends StatelessWidget {
   const CaseScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    final controller = Get.put(CaseController());
+    return Column(
+      children: [
+        Expanded(
+          child: Obx(() {
+            if (controller.isLoading.value) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (controller.cases.isEmpty) {
+              return const DataNotFound(title: 'Sorry', subtitle: 'No Case Found');
+            }
+            return ListView.builder(
+              itemCount: controller.cases.length,
+              itemBuilder: (context, index) {
+                final c = controller.cases[index];
+                return CaseTile(
+                  data: c,
+                  onTap: () => Get.to(() => CaseProfileScreen(caseData: c)),
+                  onEdit: () => Get.to(() => EditCaseScreen(caseData: c)),
+                  onDelete: () => controller.deleteCase(c),
+                );
+              },
+            );
+          }),
+        ),
+        TextButton(
+          onPressed: () => Get.to(() => const CaseListScreen()),
+          child: const Text('See All'),
+        ),
+      ],
+    );
   }
 }

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_text_from_field.dart';
+import '../../../models/party.dart';
+import '../../../models/case.dart';
+import '../controllers/edit_case_controller.dart';
+
+class EditCaseScreen extends StatelessWidget {
+  final Case caseData;
+  const EditCaseScreen({super.key, required this.caseData});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(EditCaseController(caseData));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Case')),
+      body: Obx(() {
+        return Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                spacing: 16,
+                children: [
+                  AppTextFromField(
+                    controller: controller.caseNumber,
+                    label: 'Case Number',
+                  ),
+                  AppTextFromField(
+                    controller: controller.caseName,
+                    label: 'Case Name',
+                  ),
+                  DropdownButtonFormField<Party>(
+                    value: controller.selectedParty.value,
+                    decoration: const InputDecoration(labelText: 'Party'),
+                    items: controller.parties
+                        .map((p) => DropdownMenuItem(
+                              value: p,
+                              child: Text(p.name),
+                            ))
+                        .toList(),
+                    onChanged: (p) {
+                      controller.selectedParty.value = p;
+                      controller.validate();
+                    },
+                  ),
+                  DropdownButtonFormField<String>(
+                    value: controller.selectedCourt.value.isEmpty
+                        ? null
+                        : controller.selectedCourt.value,
+                    decoration: const InputDecoration(labelText: 'Court'),
+                    items: controller.courts
+                        .map((s) => DropdownMenuItem(
+                              value: s,
+                              child: Text(s),
+                            ))
+                        .toList(),
+                    onChanged: (v) {
+                      controller.selectedCourt.value = v ?? '';
+                      controller.validate();
+                    },
+                  ),
+                  AppButton(
+                    label: 'Update',
+                    onPressed: controller.enableBtn.value
+                        ? controller.updateCase
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+            if (controller.isLoading.value)
+              const Center(child: CircularProgressIndicator()),
+          ],
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/case/services/case_service.dart
+++ b/lib/modules/case/services/case_service.dart
@@ -1,0 +1,52 @@
+import '../../../constants/app_collections.dart';
+import '../../../models/case.dart';
+import '../../../services/app_firebase.dart';
+import '../../../services/firebase_export.dart';
+
+class CaseService {
+  static final _firestore = AppFirebase().firestore;
+
+  static Future<void> addCase(Case c) async {
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(c.lawyerId)
+        .collection(AppCollections.cases)
+        .add(c.toMap());
+  }
+
+  static Future<void> updateCase(Case c) async {
+    if (c.docId == null) throw Exception('Case document id required');
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(c.lawyerId)
+        .collection(AppCollections.cases)
+        .doc(c.docId)
+        .update(c.toMap());
+  }
+
+  static Future<void> deleteCase(Case c) async {
+    if (c.docId == null) throw Exception('Case document id required');
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(c.lawyerId)
+        .collection(AppCollections.cases)
+        .doc(c.docId)
+        .delete();
+  }
+
+  static Stream<List<Case>> getCases(String lawyerId, {DateTime? date}) {
+    final ref = _firestore
+        .collection(AppCollections.lawyers)
+        .doc(lawyerId)
+        .collection(AppCollections.cases);
+    Query query = ref;
+    if (date != null) {
+      final start = DateTime(date.year, date.month, date.day);
+      final end = start.add(const Duration(days: 1));
+      query = ref.where('nextDate', isGreaterThanOrEqualTo: Timestamp.fromDate(start))
+                 .where('nextDate', isLessThan: Timestamp.fromDate(end));
+    }
+    return query.snapshots().map((snap) =>
+        snap.docs.map((d) => Case.fromMap(d.data() as Map<String, dynamic>, docId: d.id)).toList());
+  }
+}

--- a/lib/widgets/case_tile.dart
+++ b/lib/widgets/case_tile.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../models/case.dart';
+
+class CaseTile extends StatelessWidget {
+  final Case data;
+  final VoidCallback? onTap;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+
+  const CaseTile({super.key, required this.data, this.onTap, this.onEdit, this.onDelete});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        title: Text(data.caseName),
+        subtitle: Text('Next: ' + data.nextDate.toDate().toString()),
+        onTap: onTap,
+        trailing: PopupMenuButton<String>(
+          onSelected: (value) {
+            if (value == 'edit') {
+              onEdit?.call();
+            } else if (value == 'delete') {
+              onDelete?.call();
+            }
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(value: 'edit', child: Text('Edit')),
+            const PopupMenuItem(value: 'delete', child: Text('Delete')),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add service and controllers for case CRUD operations
- show today's cases with optional full list filtering
- support adding, editing and viewing cases with party & court dropdowns

## Testing
- `dart format lib/modules/case/services/case_service.dart lib/modules/case/controllers/case_controller.dart lib/modules/case/controllers/add_case_controller.dart lib/modules/case/controllers/edit_case_controller.dart lib/modules/case/screens/case_screen.dart lib/modules/case/screens/case_list_screen.dart lib/modules/case/screens/case_profile_screen.dart lib/modules/case/screens/add_case_screen.dart lib/modules/case/screens/edit_case_screen.dart lib/widgets/case_tile.dart`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe9f7e588330ab124f478e97caba