### PR TITLE
feat: restrict actions for inactive accounts

### DIFF
--- a/lib/modules/accounts/controllers/add_transaction_controller.dart
+++ b/lib/modules/accounts/controllers/add_transaction_controller.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import '../../../models/transaction.dart';
 import '../../../services/app_firebase.dart';
 import '../services/transaction_service.dart';
+import '../../../utils/activation_guard.dart';
 
 class AddTransactionController extends GetxController {
   final RxnString type = RxnString();
@@ -31,6 +32,7 @@ class AddTransactionController extends GetxController {
 
   Future<void> addTransaction() async {
     if (!enableBtn.value || isLoading.value) return;
+    if (!ActivationGuard.check()) return;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;

--- a/lib/modules/accounts/controllers/edit_transaction_controller.dart
+++ b/lib/modules/accounts/controllers/edit_transaction_controller.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 
 import '../../../models/transaction.dart';
 import '../../../services/app_firebase.dart';
+import '../../../utils/activation_guard.dart';
 
 class EditTransactionController extends GetxController {
   final Transaction transaction;
@@ -39,6 +40,7 @@ class EditTransactionController extends GetxController {
 
   Future<void> updateTransaction() async {
     if (!enableBtn.value || isLoading.value) return;
+    if (!ActivationGuard.check()) return;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;

--- a/lib/modules/accounts/screens/accounts_screen.dart
+++ b/lib/modules/accounts/screens/accounts_screen.dart
@@ -8,6 +8,7 @@ import '../services/transaction_service.dart';
 import '../widgets/transaction_tile.dart';
 import 'all_transactions_screen.dart';
 import 'edit_transaction_screen.dart';
+import '../../../utils/activation_guard.dart';
 
 class AccountsScreen extends StatelessWidget {
   const AccountsScreen({super.key});
@@ -51,10 +52,13 @@ class AccountsScreen extends StatelessWidget {
                       return TransactionTile(
                         transaction: transaction,
                         onEdit: () {
-                          Get.to(() =>
-                              EditTransactionScreen(transaction: transaction));
+                          if (ActivationGuard.check()) {
+                            Get.to(() =>
+                                EditTransactionScreen(transaction: transaction));
+                          }
                         },
                         onDelete: () async {
+                          if (!ActivationGuard.check()) return;
                           final user = AppFirebase().currentUser;
                           if (user != null && transaction.docId != null) {
                             await TransactionService.deleteTransaction(

--- a/lib/modules/accounts/screens/all_transactions_screen.dart
+++ b/lib/modules/accounts/screens/all_transactions_screen.dart
@@ -8,6 +8,7 @@ import '../controllers/transaction_controller.dart';
 import '../services/transaction_service.dart';
 import '../widgets/transaction_tile.dart';
 import 'edit_transaction_screen.dart';
+import '../../../utils/activation_guard.dart';
 
 class AllTransactionsScreen extends StatelessWidget {
   AllTransactionsScreen({super.key});
@@ -97,10 +98,13 @@ class AllTransactionsScreen extends StatelessWidget {
                   return TransactionTile(
                     transaction: transaction,
                     onEdit: () {
-                      Get.to(() =>
-                          EditTransactionScreen(transaction: transaction));
+                      if (ActivationGuard.check()) {
+                        Get.to(() =>
+                            EditTransactionScreen(transaction: transaction));
+                      }
                     },
                     onDelete: () async {
+                      if (!ActivationGuard.check()) return;
                       final user = AppFirebase().currentUser;
                       if (user != null && transaction.docId != null) {
                         await TransactionService.deleteTransaction(

--- a/lib/modules/case/controllers/add_case_controller.dart
+++ b/lib/modules/case/controllers/add_case_controller.dart
@@ -7,6 +7,7 @@ import '../../../services/app_firebase.dart';
 import '../../../services/firebase_export.dart';
 import '../../party/services/party_service.dart';
 import '../services/case_service.dart';
+import '../../../utils/activation_guard.dart';
 
 class AddCaseController extends GetxController {
   final caseNumber = TextEditingController();
@@ -70,6 +71,7 @@ class AddCaseController extends GetxController {
 
   Future<void> addCase() async {
     if (!enableBtn.value || isLoading.value) return;
+    if (!ActivationGuard.check()) return;
     final user = AppFirebase().currentUser;
     if (user == null) return;
     try {

--- a/lib/modules/case/controllers/edit_case_controller.dart
+++ b/lib/modules/case/controllers/edit_case_controller.dart
@@ -7,6 +7,7 @@ import '../../../services/app_firebase.dart';
 import '../../../services/firebase_export.dart';
 import '../../party/services/party_service.dart';
 import '../services/case_service.dart';
+import '../../../utils/activation_guard.dart';
 
 class EditCaseController extends GetxController {
   EditCaseController(this.caseData);
@@ -93,6 +94,7 @@ class EditCaseController extends GetxController {
 
   Future<void> updateCase() async {
     if (!enableBtn.value || isLoading.value) return;
+    if (!ActivationGuard.check()) return;
     final user = AppFirebase().currentUser;
     if (user == null) return;
     try {

--- a/lib/modules/case/screens/case_list_screen.dart
+++ b/lib/modules/case/screens/case_list_screen.dart
@@ -6,6 +6,7 @@ import '../../../widgets/data_not_found.dart';
 import '../controllers/case_controller.dart';
 import 'case_profile_screen.dart';
 import 'edit_case_screen.dart';
+import '../../../utils/activation_guard.dart';
 
 class CaseListScreen extends StatefulWidget {
   const CaseListScreen({super.key});
@@ -61,8 +62,16 @@ class _CaseListScreenState extends State<CaseListScreen> {
             return CaseTile(
               data: c,
               onTap: () => Get.to(() => CaseProfileScreen(caseData: c)),
-              onEdit: () => Get.to(() => EditCaseScreen(caseData: c)),
-              onDelete: () => controller.deleteCase(c),
+              onEdit: () {
+                if (ActivationGuard.check()) {
+                  Get.to(() => EditCaseScreen(caseData: c));
+                }
+              },
+              onDelete: () {
+                if (ActivationGuard.check()) {
+                  controller.deleteCase(c);
+                }
+              },
             );
           },
         );

--- a/lib/modules/case/screens/case_profile_screen.dart
+++ b/lib/modules/case/screens/case_profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import '../../../models/case.dart';
 import '../controllers/case_controller.dart';
 import 'edit_case_screen.dart';
+import '../../../utils/activation_guard.dart';
 
 class CaseProfileScreen extends StatelessWidget {
   final Case caseData;
@@ -18,13 +19,19 @@ class CaseProfileScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.edit),
-            onPressed: () => Get.to(() => EditCaseScreen(caseData: caseData)),
+            onPressed: () {
+              if (ActivationGuard.check()) {
+                Get.to(() => EditCaseScreen(caseData: caseData));
+              }
+            },
           ),
           IconButton(
             icon: const Icon(Icons.delete),
             onPressed: () {
-              controller.deleteCase(caseData);
-              Get.back();
+              if (ActivationGuard.check()) {
+                controller.deleteCase(caseData);
+                Get.back();
+              }
             },
           ),
         ],

--- a/lib/modules/case/screens/case_screen.dart
+++ b/lib/modules/case/screens/case_screen.dart
@@ -7,6 +7,7 @@ import '../controllers/case_controller.dart';
 import 'case_list_screen.dart';
 import 'case_profile_screen.dart';
 import 'edit_case_screen.dart';
+import '../../../utils/activation_guard.dart';
 
 class CaseScreen extends StatelessWidget {
   const CaseScreen({super.key});
@@ -31,8 +32,16 @@ class CaseScreen extends StatelessWidget {
                 return CaseTile(
                   data: c,
                   onTap: () => Get.to(() => CaseProfileScreen(caseData: c)),
-                  onEdit: () => Get.to(() => EditCaseScreen(caseData: c)),
-                  onDelete: () => controller.deleteCase(c),
+                  onEdit: () {
+                    if (ActivationGuard.check()) {
+                      Get.to(() => EditCaseScreen(caseData: c));
+                    }
+                  },
+                  onDelete: () {
+                    if (ActivationGuard.check()) {
+                      controller.deleteCase(c);
+                    }
+                  },
                 );
               },
             );

--- a/lib/modules/layout/screens/layout_screen.dart
+++ b/lib/modules/layout/screens/layout_screen.dart
@@ -13,6 +13,7 @@ import '../../party/screens/party_screen.dart';
 import '../widgets/app_drawer.dart';
 import '../controllers/layout_controller.dart';
 import '../widgets/dashboard.dart';
+import '../../../utils/activation_guard.dart';
 
 class LayoutScreen extends StatelessWidget {
   LayoutScreen({super.key});
@@ -59,6 +60,7 @@ class LayoutScreen extends StatelessWidget {
                 curve: Curves.easeInOut,
                 child: FloatingActionButton(
                   onPressed: () {
+                    if (!ActivationGuard.check()) return;
                     final index = DefaultTabController.of(context).index;
                     if (index == 0) {
                       // add later

--- a/lib/modules/party/controllers/add_party_controller.dart
+++ b/lib/modules/party/controllers/add_party_controller.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../../models/party.dart';
 import '../../../services/app_firebase.dart';
 import '../services/party_service.dart';
+import '../../../utils/activation_guard.dart';
 
 class AddPartyController extends GetxController {
   final name = TextEditingController();
@@ -69,6 +70,7 @@ class AddPartyController extends GetxController {
 
   Future<void> addParty() async {
     if (!enableBtn.value || isLoading.value) return;
+    if (!ActivationGuard.check()) return;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;

--- a/lib/modules/party/controllers/edit_party_controller.dart
+++ b/lib/modules/party/controllers/edit_party_controller.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../../models/party.dart';
 import '../../../services/app_firebase.dart';
 import '../services/party_service.dart';
+import '../../../utils/activation_guard.dart';
 
 class EditPartyController extends GetxController {
   final Party party;
@@ -76,6 +77,7 @@ class EditPartyController extends GetxController {
 
   Future<void> updateParty() async {
     if (!enableBtn.value || isLoading.value) return;
+    if (!ActivationGuard.check()) return;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;

--- a/lib/modules/party/controllers/party_profile_controller.dart
+++ b/lib/modules/party/controllers/party_profile_controller.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import '../../../models/party.dart';
 import '../services/party_service.dart';
+import '../../../utils/activation_guard.dart';
 
 class PartyProfileController extends GetxController {
   final Party party;
@@ -12,6 +13,7 @@ class PartyProfileController extends GetxController {
 
   Future<void> deleteParty() async {
     if (isDeleting.value) return;
+    if (!ActivationGuard.check()) return;
     try {
       isDeleting.value = true;
       await PartyService.deleteParty(party);

--- a/lib/modules/party/screens/party_profile_screen.dart
+++ b/lib/modules/party/screens/party_profile_screen.dart
@@ -6,6 +6,7 @@ import '../../../widgets/app_button.dart';
 import '../../../widgets/app_info_row.dart';
 import '../controllers/party_profile_controller.dart';
 import 'edit_party_screen.dart';
+import '../../../utils/activation_guard.dart';
 
 class PartyProfileScreen extends StatelessWidget {
   final Party party;
@@ -45,7 +46,9 @@ class PartyProfileScreen extends StatelessWidget {
                         child: AppButton(
                           label: 'এডিট',
                           onPressed: () {
-                            Get.to(() => EditPartyScreen(party: party));
+                            if (ActivationGuard.check()) {
+                              Get.to(() => EditPartyScreen(party: party));
+                            }
                           },
                         ),
                       ),
@@ -55,7 +58,11 @@ class PartyProfileScreen extends StatelessWidget {
                           label: 'ডিলিট',
                           onPressed: controller.isDeleting.value
                               ? null
-                              : controller.deleteParty,
+                              : () {
+                                  if (ActivationGuard.check()) {
+                                    controller.deleteParty();
+                                  }
+                                },
                         ),
                       ),
                     ],

--- a/lib/utils/activation_guard.dart
+++ b/lib/utils/activation_guard.dart
@@ -1,0 +1,25 @@
+import 'package:get/get.dart';
+
+import '../modules/layout/controllers/layout_controller.dart';
+import '../modules/court_dairy/screens/account_activation_screen.dart';
+
+class ActivationGuard {
+  /// Returns true if the current lawyer account is active.
+  static bool isActive() {
+    try {
+      final layout = Get.find<LayoutController>();
+      return layout.lawyer.value?.isActive ?? false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Ensures the account is active before performing an action.
+  /// Navigates to [AccountActivationScreen] and returns false if inactive.
+  static bool check() {
+    if (isActive()) return true;
+    Get.to(() => AccountActivationScreen());
+    return false;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `ActivationGuard` to redirect inactive users to account activation
- guard floating action button, case, party and account operations with activation check

## Testing
- `dart format lib/utils/activation_guard.dart lib/modules/layout/screens/layout_screen.dart lib/modules/case/screens/case_list_screen.dart lib/modules/case/screens/case_screen.dart lib/modules/case/screens/case_profile_screen.dart lib/modules/case/controllers/add_case_controller.dart lib/modules/case/controllers/edit_case_controller.dart lib/modules/party/controllers/add_party_controller.dart lib/modules/party/controllers/edit_party_controller.dart lib/modules/party/controllers/party_profile_controller.dart lib/modules/party/screens/party_profile_screen.dart lib/modules/accounts/controllers/add_transaction_controller.dart lib/modules/accounts/controllers/edit_transaction_controller.dart lib/modules/accounts/screens/accounts_screen.dart lib/modules/accounts/screens/all_transactions_screen.dart` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b203f40d8483309e7db2527e59bad5