### PR TITLE
feat: add case module with stepper form

### DIFF
--- a/lib/modules/case/controllers/add_case_controller.dart
+++ b/lib/modules/case/controllers/add_case_controller.dart
@@ -1,0 +1,70 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/court_case.dart';
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../../party/services/party_service.dart';
+import '../services/case_service.dart';
+
+class AddCaseController extends GetxController {
+  final caseTitle = TextEditingController();
+  final courtName = TextEditingController();
+  final caseNumber = TextEditingController();
+  final caseStatus = TextEditingController();
+  final caseSummary = TextEditingController();
+  final judgeName = TextEditingController();
+  final courtOrder = TextEditingController();
+  final document = TextEditingController();
+
+  final RxnString selectedCaseType = RxnString();
+  final Rx<DateTime?> filedDate = Rx<DateTime?>(null);
+  final Rx<DateTime?> hearingDate = Rx<DateTime?>(null);
+
+  final Rx<Party?> selectedPlaintiff = Rx<Party?>(null);
+  final Rx<Party?> selectedDefendant = Rx<Party?>(null);
+
+  final parties = <Party>[].obs;
+  final caseTypes = ['Civil', 'Criminal', 'Family', 'Other'];
+
+  @override
+  void onInit() {
+    super.onInit();
+    final user = AppFirebase().currentUser;
+    if (user != null) {
+      PartyService.getParties(user.uid).listen((list) {
+        parties.value = list;
+      });
+    }
+  }
+
+  Future<void> addCase() async {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+
+    final caseModel = CourtCase(
+      docId: '',
+      caseType: selectedCaseType.value ?? '',
+      caseTitle: caseTitle.text.trim(),
+      courtName: courtName.text.trim(),
+      caseNumber: caseNumber.text.trim(),
+      filedDate: Timestamp.fromDate(filedDate.value ?? DateTime.now()),
+      caseStatus: caseStatus.text.trim(),
+      plaintiff: selectedPlaintiff.value!,
+      defendant: selectedDefendant.value!,
+      hearingDates: hearingDate.value != null
+          ? [Timestamp.fromDate(hearingDate.value!)]
+          : <Timestamp>[],
+      judgeName: judgeName.text.trim(),
+      documentsAttached:
+          document.text.isNotEmpty ? [document.text.trim()] : <String>[],
+      courtOrders:
+          courtOrder.text.isNotEmpty ? [courtOrder.text.trim()] : <String>[],
+      caseSummary: caseSummary.text.trim(),
+    );
+
+    await CaseService.addCase(caseModel, user.uid);
+    Get.back();
+  }
+}

--- a/lib/modules/case/controllers/case_controller.dart
+++ b/lib/modules/case/controllers/case_controller.dart
@@ -1,0 +1,30 @@
+import 'package:get/get.dart';
+
+import '../../../models/court_case.dart';
+import '../../../services/app_firebase.dart';
+import '../services/case_service.dart';
+
+class CaseController extends GetxController {
+  final cases = <CourtCase>[].obs;
+  final isLoading = true.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    final user = AppFirebase().currentUser;
+    if (user != null) {
+      CaseService.getCases(user.uid).listen((event) {
+        cases.value = event;
+        isLoading.value = false;
+      });
+    } else {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> deleteCase(String docId) async {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+    await CaseService.deleteCase(docId, user.uid);
+  }
+}

--- a/lib/modules/case/controllers/edit_case_controller.dart
+++ b/lib/modules/case/controllers/edit_case_controller.dart
@@ -1,0 +1,92 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/court_case.dart';
+import '../../../models/party.dart';
+import '../../../services/app_firebase.dart';
+import '../../party/services/party_service.dart';
+import '../services/case_service.dart';
+
+class EditCaseController extends GetxController {
+  EditCaseController(this.caseModel);
+
+  final CourtCase caseModel;
+
+  late final TextEditingController caseTitle;
+  late final TextEditingController courtName;
+  late final TextEditingController caseNumber;
+  late final TextEditingController caseStatus;
+  late final TextEditingController caseSummary;
+  late final TextEditingController judgeName;
+  late final TextEditingController courtOrder;
+  late final TextEditingController document;
+
+  final RxnString selectedCaseType = RxnString();
+  final Rx<DateTime?> filedDate = Rx<DateTime?>(null);
+  final Rx<DateTime?> hearingDate = Rx<DateTime?>(null);
+
+  final Rx<Party?> selectedPlaintiff = Rx<Party?>(null);
+  final Rx<Party?> selectedDefendant = Rx<Party?>(null);
+
+  final parties = <Party>[].obs;
+  final caseTypes = ['Civil', 'Criminal', 'Family', 'Other'];
+
+  @override
+  void onInit() {
+    super.onInit();
+    caseTitle = TextEditingController(text: caseModel.caseTitle);
+    courtName = TextEditingController(text: caseModel.courtName);
+    caseNumber = TextEditingController(text: caseModel.caseNumber);
+    caseStatus = TextEditingController(text: caseModel.caseStatus);
+    caseSummary = TextEditingController(text: caseModel.caseSummary);
+    judgeName = TextEditingController(text: caseModel.judgeName);
+    courtOrder = TextEditingController(
+        text: caseModel.courtOrders.isNotEmpty ? caseModel.courtOrders.first : '');
+    document = TextEditingController(
+        text: caseModel.documentsAttached.isNotEmpty
+            ? caseModel.documentsAttached.first
+            : '');
+    selectedCaseType.value = caseModel.caseType;
+    filedDate.value = caseModel.filedDate.toDate();
+    if (caseModel.hearingDates.isNotEmpty) {
+      hearingDate.value = caseModel.hearingDates.first.toDate();
+    }
+    selectedPlaintiff.value = caseModel.plaintiff;
+    selectedDefendant.value = caseModel.defendant;
+
+    final user = AppFirebase().currentUser;
+    if (user != null) {
+      PartyService.getParties(user.uid).listen((list) {
+        parties.value = list;
+      });
+    }
+  }
+
+  Future<void> updateCase() async {
+    final user = AppFirebase().currentUser;
+    if (user == null) return;
+
+    caseModel
+      ..caseType = selectedCaseType.value ?? ''
+      ..caseTitle = caseTitle.text.trim()
+      ..courtName = courtName.text.trim()
+      ..caseNumber = caseNumber.text.trim()
+      ..filedDate = Timestamp.fromDate(filedDate.value ?? DateTime.now())
+      ..caseStatus = caseStatus.text.trim()
+      ..plaintiff = selectedPlaintiff.value!
+      ..defendant = selectedDefendant.value!
+      ..hearingDates = hearingDate.value != null
+          ? [Timestamp.fromDate(hearingDate.value!)]
+          : <Timestamp>[]
+      ..judgeName = judgeName.text.trim()
+      ..documentsAttached =
+          document.text.isNotEmpty ? [document.text.trim()] : <String>[]
+      ..courtOrders =
+          courtOrder.text.isNotEmpty ? [courtOrder.text.trim()] : <String>[]
+      ..caseSummary = caseSummary.text.trim();
+
+    await CaseService.updateCase(caseModel, user.uid);
+    Get.back();
+  }
+}

--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -1,0 +1,145 @@
+import 'package:dynamic_multi_step_form/dynamic_multi_step_form.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/add_case_controller.dart';
+import '../../../models/party.dart';
+
+class AddCaseScreen extends StatelessWidget {
+  const AddCaseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(AddCaseController());
+
+    Widget caseTypeChips() {
+      return Wrap(
+        spacing: 8,
+        children: controller.caseTypes.map((type) {
+          return Obx(() => ChoiceChip(
+                label: Text(type),
+                selected: controller.selectedCaseType.value == type,
+                onSelected: (_) => controller.selectedCaseType.value = type,
+              ));
+        }).toList(),
+      );
+    }
+
+    Widget partyDropdown(Rx<Party?> selected) {
+      return Obx(() => DropdownButton<Party>(
+            value: selected.value,
+            hint: const Text('Select'),
+            items: controller.parties
+                .map((p) => DropdownMenuItem(
+                      value: p,
+                      child: Text(p.name),
+                    ))
+                .toList(),
+            onChanged: (v) => selected.value = v,
+          ));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Case')),
+      body: DynamicMultiStepForm(
+        steps: [
+          FormStep(
+            title: const Text('Case Info'),
+            content: Column(
+              children: [
+                caseTypeChips(),
+                TextField(
+                  controller: controller.caseTitle,
+                  decoration: const InputDecoration(labelText: 'Case Title'),
+                ),
+                TextField(
+                  controller: controller.courtName,
+                  decoration: const InputDecoration(labelText: 'Court Name'),
+                ),
+                TextField(
+                  controller: controller.caseNumber,
+                  decoration: const InputDecoration(labelText: 'Case Number'),
+                ),
+                TextField(
+                  controller: controller.caseStatus,
+                  decoration: const InputDecoration(labelText: 'Case Status'),
+                ),
+                TextField(
+                  controller: controller.caseSummary,
+                  decoration: const InputDecoration(labelText: 'Summary'),
+                ),
+                Obx(() => ListTile(
+                      title: Text(controller.filedDate.value == null
+                          ? 'Filed Date'
+                          : controller.filedDate.value
+                              .toString()
+                              .split(' ')
+                              .first),
+                      trailing: const Icon(Icons.calendar_today),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                            context: context,
+                            initialDate: controller.filedDate.value ?? DateTime.now(),
+                            firstDate: DateTime(2000),
+                            lastDate: DateTime(2100));
+                        if (picked != null) controller.filedDate.value = picked;
+                      },
+                    )),
+              ],
+            ),
+          ),
+          FormStep(
+            title: const Text('Parties'),
+            content: Column(
+              children: [
+                const Text('Plaintiff'),
+                partyDropdown(controller.selectedPlaintiff),
+                const SizedBox(height: 16),
+                const Text('Defendant'),
+                partyDropdown(controller.selectedDefendant),
+              ],
+            ),
+          ),
+          FormStep(
+            title: const Text('More'),
+            content: Column(
+              children: [
+                Obx(() => ListTile(
+                      title: Text(controller.hearingDate.value == null
+                          ? 'Hearing Date'
+                          : controller.hearingDate.value
+                              .toString()
+                              .split(' ')
+                              .first),
+                      trailing: const Icon(Icons.calendar_today),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                            context: context,
+                            initialDate:
+                                controller.hearingDate.value ?? DateTime.now(),
+                            firstDate: DateTime(2000),
+                            lastDate: DateTime(2100));
+                        if (picked != null) controller.hearingDate.value = picked;
+                      },
+                    )),
+                TextField(
+                  controller: controller.judgeName,
+                  decoration: const InputDecoration(labelText: 'Judge Name'),
+                ),
+                TextField(
+                  controller: controller.courtOrder,
+                  decoration: const InputDecoration(labelText: 'Court Order'),
+                ),
+                TextField(
+                  controller: controller.document,
+                  decoration: const InputDecoration(labelText: 'Document'),
+                ),
+              ],
+            ),
+          ),
+        ],
+        onSubmit: controller.addCase,
+      ),
+    );
+  }
+}

--- a/lib/modules/case/screens/case_screen.dart
+++ b/lib/modules/case/screens/case_screen.dart
@@ -1,10 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/case_controller.dart';
+import '../widgets/case_tile.dart';
+import 'add_case_screen.dart';
 
 class CaseScreen extends StatelessWidget {
   const CaseScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    final controller = Get.put(CaseController());
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cases')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.cases.isEmpty) {
+          return const Center(child: Text('No cases found'));
+        }
+        return ListView.builder(
+          itemCount: controller.cases.length,
+          itemBuilder: (_, i) => CaseTile(caseItem: controller.cases[i]),
+        );
+      }),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Get.to(() => const AddCaseScreen()),
+        child: const Icon(Icons.add),
+      ),
+    );
   }
 }

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -1,0 +1,148 @@
+import 'package:dynamic_multi_step_form/dynamic_multi_step_form.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/court_case.dart';
+import '../../../models/party.dart';
+import '../controllers/edit_case_controller.dart';
+
+class EditCaseScreen extends StatelessWidget {
+  const EditCaseScreen(this.caseItem, {super.key});
+
+  final CourtCase caseItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(EditCaseController(caseItem));
+
+    Widget caseTypeChips() {
+      return Wrap(
+        spacing: 8,
+        children: controller.caseTypes.map((type) {
+          return Obx(() => ChoiceChip(
+                label: Text(type),
+                selected: controller.selectedCaseType.value == type,
+                onSelected: (_) => controller.selectedCaseType.value = type,
+              ));
+        }).toList(),
+      );
+    }
+
+    Widget partyDropdown(Rx<Party?> selected) {
+      return Obx(() => DropdownButton<Party>(
+            value: selected.value,
+            hint: const Text('Select'),
+            items: controller.parties
+                .map((p) => DropdownMenuItem(
+                      value: p,
+                      child: Text(p.name),
+                    ))
+                .toList(),
+            onChanged: (v) => selected.value = v,
+          ));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Case')),
+      body: DynamicMultiStepForm(
+        steps: [
+          FormStep(
+            title: const Text('Case Info'),
+            content: Column(
+              children: [
+                caseTypeChips(),
+                TextField(
+                  controller: controller.caseTitle,
+                  decoration: const InputDecoration(labelText: 'Case Title'),
+                ),
+                TextField(
+                  controller: controller.courtName,
+                  decoration: const InputDecoration(labelText: 'Court Name'),
+                ),
+                TextField(
+                  controller: controller.caseNumber,
+                  decoration: const InputDecoration(labelText: 'Case Number'),
+                ),
+                TextField(
+                  controller: controller.caseStatus,
+                  decoration: const InputDecoration(labelText: 'Case Status'),
+                ),
+                TextField(
+                  controller: controller.caseSummary,
+                  decoration: const InputDecoration(labelText: 'Summary'),
+                ),
+                Obx(() => ListTile(
+                      title: Text(controller.filedDate.value == null
+                          ? 'Filed Date'
+                          : controller.filedDate.value
+                              .toString()
+                              .split(' ')
+                              .first),
+                      trailing: const Icon(Icons.calendar_today),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                            context: context,
+                            initialDate: controller.filedDate.value ?? DateTime.now(),
+                            firstDate: DateTime(2000),
+                            lastDate: DateTime(2100));
+                        if (picked != null) controller.filedDate.value = picked;
+                      },
+                    )),
+              ],
+            ),
+          ),
+          FormStep(
+            title: const Text('Parties'),
+            content: Column(
+              children: [
+                const Text('Plaintiff'),
+                partyDropdown(controller.selectedPlaintiff),
+                const SizedBox(height: 16),
+                const Text('Defendant'),
+                partyDropdown(controller.selectedDefendant),
+              ],
+            ),
+          ),
+          FormStep(
+            title: const Text('More'),
+            content: Column(
+              children: [
+                Obx(() => ListTile(
+                      title: Text(controller.hearingDate.value == null
+                          ? 'Hearing Date'
+                          : controller.hearingDate.value
+                              .toString()
+                              .split(' ')
+                              .first),
+                      trailing: const Icon(Icons.calendar_today),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                            context: context,
+                            initialDate:
+                                controller.hearingDate.value ?? DateTime.now(),
+                            firstDate: DateTime(2000),
+                            lastDate: DateTime(2100));
+                        if (picked != null) controller.hearingDate.value = picked;
+                      },
+                    )),
+                TextField(
+                  controller: controller.judgeName,
+                  decoration: const InputDecoration(labelText: 'Judge Name'),
+                ),
+                TextField(
+                  controller: controller.courtOrder,
+                  decoration: const InputDecoration(labelText: 'Court Order'),
+                ),
+                TextField(
+                  controller: controller.document,
+                  decoration: const InputDecoration(labelText: 'Document'),
+                ),
+              ],
+            ),
+          ),
+        ],
+        onSubmit: controller.updateCase,
+      ),
+    );
+  }
+}

--- a/lib/modules/case/services/case_service.dart
+++ b/lib/modules/case/services/case_service.dart
@@ -1,0 +1,50 @@
+import '../../../constants/app_collections.dart';
+import '../../../models/court_case.dart';
+import '../../../services/app_firebase.dart';
+
+class CaseService {
+  static final _firestore = AppFirebase().firestore;
+
+  static Future<void> addCase(CourtCase courtCase, String userId) async {
+    final docRef = _firestore
+        .collection(AppCollections.lawyers)
+        .doc(userId)
+        .collection(AppCollections.cases)
+        .doc();
+    courtCase.docId = docRef.id;
+    await docRef.set(courtCase.toMap());
+  }
+
+  static Future<void> updateCase(CourtCase courtCase, String userId) async {
+    final docId = courtCase.docId;
+    if (docId.isEmpty) {
+      throw Exception('Case document ID is required for update');
+    }
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(userId)
+        .collection(AppCollections.cases)
+        .doc(docId)
+        .update(courtCase.toMap());
+  }
+
+  static Stream<List<CourtCase>> getCases(String userId) {
+    return _firestore
+        .collection(AppCollections.lawyers)
+        .doc(userId)
+        .collection(AppCollections.cases)
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => CourtCase.fromMap(doc.data()))
+            .toList());
+  }
+
+  static Future<void> deleteCase(String docId, String userId) async {
+    await _firestore
+        .collection(AppCollections.lawyers)
+        .doc(userId)
+        .collection(AppCollections.cases)
+        .doc(docId)
+        .delete();
+  }
+}

--- a/lib/modules/case/widgets/case_tile.dart
+++ b/lib/modules/case/widgets/case_tile.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/court_case.dart';
+import '../controllers/case_controller.dart';
+import '../screens/edit_case_screen.dart';
+
+class CaseTile extends StatelessWidget {
+  const CaseTile({super.key, required this.caseItem});
+
+  final CourtCase caseItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CaseController>();
+    return ListTile(
+      title: Text(caseItem.caseTitle),
+      subtitle: Text(caseItem.caseNumber),
+      onTap: () {
+        Get.to(() => EditCaseScreen(caseItem));
+      },
+      trailing: IconButton(
+        icon: const Icon(Icons.delete_outline),
+        onPressed: () => controller.deleteCase(caseItem.docId),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,7 @@ dependencies:
   lottie: ^3.3.1
   dio: ^5.9.0
   image_picker: ^1.1.5
+  dynamic_multi_step_form: ^0.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement Firestore service and controllers for court cases
- add case listing, creation, and editing screens with dynamic multi-step form
- include party dropdowns, case type chips, and optional hearing/judge fields

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31023dc3883308196dfd10c36d361