### PR TITLE
Improve edit transaction screen dropdowns and safe area

### DIFF
--- a/lib/modules/accounts/screens/edit_transaction_screen.dart
+++ b/lib/modules/accounts/screens/edit_transaction_screen.dart
@@ -3,7 +3,6 @@ import 'package:get/get.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
-import '../../../widgets/app_dropdown.dart';
 import '../../../utils/payment_methods.dart';
 import '../../../utils/transaction_types.dart';
 import '../../../models/transaction.dart';
@@ -28,13 +27,46 @@ class EditTransactionScreen extends StatelessWidget {
               child: Column(
                 spacing: 16,
                 children: [
-                  AppDropdown(
+                  DropdownButtonFormField<String>(
                     value: controller.type.value,
-                    label: 'ধরণ',
-                    hintText: 'লেনদেনের ধরণ নির্বাচন করুন',
-                    items: getTransactionTypes(),
-                    prefixIcon: Icons.category,
-                    onChanged: (val) => controller.type.value = val,
+                    isExpanded: true,
+                    borderRadius: BorderRadius.circular(12),
+                    menuMaxHeight: 320,
+                    icon:
+                        const Icon(Icons.keyboard_arrow_down_rounded),
+                    decoration: InputDecoration(
+                      labelText: 'ধরণ',
+                      hintText: 'লেনদেনের ধরণ নির্বাচন করুন',
+                      prefixIcon: const Icon(Icons.category),
+                      filled: true,
+                      fillColor: Theme.of(context)
+                          .colorScheme
+                          .surface
+                          .withOpacity(0.7),
+                      contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 12),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: Theme.of(context).colorScheme.outlineVariant,
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: Theme.of(context).colorScheme.primary,
+                          width: 1.4,
+                        ),
+                      ),
+                    ),
+                    items: getTransactionTypes()
+                        .map((e) =>
+                            DropdownMenuItem(value: e, child: Text(e)))
+                        .toList(),
+                    onChanged: (v) => controller.type.value = v,
                   ),
                   AppTextFromField(
                     controller: controller.amount,
@@ -43,13 +75,46 @@ class EditTransactionScreen extends StatelessWidget {
                     prefixIcon: Icons.money,
                     keyboardType: TextInputType.number,
                   ),
-                  AppDropdown(
+                  DropdownButtonFormField<String>(
                     value: controller.paymentMethod.value,
-                    label: 'পেমেন্ট পদ্ধতি',
-                    hintText: 'পেমেন্ট পদ্ধতি নির্বাচন করুন',
-                    items: paymentMethods,
-                    prefixIcon: Icons.payment,
-                    onChanged: (val) => controller.paymentMethod.value = val,
+                    isExpanded: true,
+                    borderRadius: BorderRadius.circular(12),
+                    menuMaxHeight: 320,
+                    icon:
+                        const Icon(Icons.keyboard_arrow_down_rounded),
+                    decoration: InputDecoration(
+                      labelText: 'পেমেন্ট পদ্ধতি',
+                      hintText: 'পেমেন্ট পদ্ধতি নির্বাচন করুন',
+                      prefixIcon: const Icon(Icons.payment),
+                      filled: true,
+                      fillColor: Theme.of(context)
+                          .colorScheme
+                          .surface
+                          .withOpacity(0.7),
+                      contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 12),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: Theme.of(context).colorScheme.outlineVariant,
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: Theme.of(context).colorScheme.primary,
+                          width: 1.4,
+                        ),
+                      ),
+                    ),
+                    items: paymentMethods
+                        .map((e) =>
+                            DropdownMenuItem(value: e, child: Text(e)))
+                        .toList(),
+                    onChanged: (v) => controller.paymentMethod.value = v,
                   ),
                   AppTextFromField(
                     controller: controller.note,
@@ -68,13 +133,16 @@ class EditTransactionScreen extends StatelessWidget {
         );
       }),
       bottomNavigationBar: Obx(
-        () => Padding(
-          padding: const EdgeInsets.all(16),
-          child: AppButton(
-            label: 'আপডেট করুন',
-            onPressed: controller.enableBtn.value
-                ? controller.updateTransaction
-                : null,
+        () => SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: AppButton(
+              label: 'আপডেট করুন',
+              onPressed: controller.enableBtn.value
+                  ? controller.updateTransaction
+                  : null,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- Replace custom dropdowns with styled `DropdownButtonFormField` widgets to match other screens
- Wrap update button in a `SafeArea` to avoid system navigation bar overlap

## Testing
- `dart format lib/modules/accounts/screens/edit_transaction_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b33556798083309eb9c36466fa3b6a