### PR TITLE
feat: confirm dialogs and button loading

### DIFF
--- a/lib/modules/accounts/controllers/add_transaction_controller.dart
+++ b/lib/modules/accounts/controllers/add_transaction_controller.dart
@@ -30,9 +30,9 @@ class AddTransactionController extends GetxController {
         paymentMethod.value != null;
   }
 
-  Future<void> addTransaction() async {
-    if (!enableBtn.value || isLoading.value) return;
-    if (!ActivationGuard.check()) return;
+  Future<bool> addTransaction() async {
+    if (!enableBtn.value || isLoading.value) return false;
+    if (!ActivationGuard.check()) return false;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;
@@ -49,21 +49,9 @@ class AddTransactionController extends GetxController {
       );
 
       await TransactionService.addTransaction(transaction, user.uid);
-
-      Get.back();
-      Get.snackbar(
-        'সফল হয়েছে',
-        'লেনদেন যুক্ত করা হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.green,
-      );
+      return true;
     } catch (e) {
-      Get.snackbar(
-        'ত্রুটি',
-        'লেনদেন যুক্ত করতে ব্যর্থ হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.red,
-      );
+      return false;
     } finally {
       isLoading.value = false;
     }

--- a/lib/modules/accounts/controllers/edit_transaction_controller.dart
+++ b/lib/modules/accounts/controllers/edit_transaction_controller.dart
@@ -38,9 +38,9 @@ class EditTransactionController extends GetxController {
         paymentMethod.value != null;
   }
 
-  Future<void> updateTransaction() async {
-    if (!enableBtn.value || isLoading.value) return;
-    if (!ActivationGuard.check()) return;
+  Future<bool> updateTransaction() async {
+    if (!enableBtn.value || isLoading.value) return false;
+    if (!ActivationGuard.check()) return false;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;
@@ -59,21 +59,9 @@ class EditTransactionController extends GetxController {
       );
 
       await TransactionService.updateTransaction(updated, user.uid);
-
-      Get.back();
-      Get.snackbar(
-        'সফল হয়েছে',
-        'লেনদেন আপডেট করা হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.green,
-      );
+      return true;
     } catch (e) {
-      Get.snackbar(
-        'ত্রুটি',
-        'লেনদেন আপডেট করতে ব্যর্থ হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.red,
-      );
+      return false;
     } finally {
       isLoading.value = false;
     }

--- a/lib/modules/accounts/screens/add_transaction_screen.dart
+++ b/lib/modules/accounts/screens/add_transaction_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
@@ -18,118 +19,112 @@ class AddTransactionScreen extends StatelessWidget {
         title: const Text('নতুন লেনদেন যুক্ত করুন'),
       ),
       body: Obx(() {
-        return Stack(
-          children: [
-            SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                spacing: 16,
-                children: [
-                  DropdownButtonFormField<String>(
-                    value: controller.type.value,
-                    isExpanded: true,
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            spacing: 16,
+            children: [
+              DropdownButtonFormField<String>(
+                value: controller.type.value,
+                isExpanded: true,
+                borderRadius: BorderRadius.circular(12),
+                menuMaxHeight: 320,
+                icon: const Icon(Icons.keyboard_arrow_down_rounded),
+                decoration: InputDecoration(
+                  labelText: 'ধরণ',
+                  hintText: 'লেনদেনের ধরণ নির্বাচন করুন',
+                  prefixIcon: const Icon(Icons.category),
+                  filled: true,
+                  fillColor: Theme.of(context)
+                      .colorScheme
+                      .surface
+                      .withOpacity(0.7),
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                  border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
-                    menuMaxHeight: 320,
-                    icon: const Icon(Icons.keyboard_arrow_down_rounded),
-                    decoration: InputDecoration(
-                      labelText: 'ধরণ',
-                      hintText: 'লেনদেনের ধরণ নির্বাচন করুন',
-                      prefixIcon: const Icon(Icons.category),
-                      filled: true,
-                      fillColor: Theme.of(context)
-                          .colorScheme
-                          .surface
-                          .withOpacity(0.7),
-                      contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 12),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: Theme.of(context).colorScheme.outlineVariant,
-                        ),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: Theme.of(context).colorScheme.primary,
-                          width: 1.4,
-                        ),
-                      ),
-                    ),
-                    items: getTransactionTypes()
-                        .map((e) => DropdownMenuItem(
-                              value: e,
-                              child: Text(e),
-                            ))
-                        .toList(),
-                    onChanged: (v) => controller.type.value = v,
                   ),
-                  AppTextFromField(
-                    controller: controller.amount,
-                    label: 'পরিমাণ',
-                    hintText: 'পরিমাণ লিখুন',
-                    prefixIcon: Icons.money,
-                    keyboardType: TextInputType.number,
-                  ),
-                  DropdownButtonFormField<String>(
-                    value: controller.paymentMethod.value,
-                    isExpanded: true,
+                  enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
-                    menuMaxHeight: 320,
-                    icon: const Icon(Icons.keyboard_arrow_down_rounded),
-                    decoration: InputDecoration(
-                      labelText: 'পেমেন্ট পদ্ধতি',
-                      hintText: 'পেমেন্ট পদ্ধতি নির্বাচন করুন',
-                      prefixIcon: const Icon(Icons.payment),
-                      filled: true,
-                      fillColor: Theme.of(context)
-                          .colorScheme
-                          .surface
-                          .withOpacity(0.7),
-                      contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 12),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: Theme.of(context).colorScheme.outlineVariant,
-                        ),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: Theme.of(context).colorScheme.primary,
-                          width: 1.4,
-                        ),
-                      ),
+                    borderSide: BorderSide(
+                      color: Theme.of(context).colorScheme.outlineVariant,
                     ),
-                    items: paymentMethods
-                        .map((e) => DropdownMenuItem(
-                              value: e,
-                              child: Text(e),
-                            ))
-                        .toList(),
-                    onChanged: (v) => controller.paymentMethod.value = v,
                   ),
-                  AppTextFromField(
-                    controller: controller.note,
-                    label: 'নোট',
-                    hintText: 'নোট লিখুন',
-                    prefixIcon: Icons.note,
-                    isMaxLines: 3,
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: Theme.of(context).colorScheme.primary,
+                      width: 1.4,
+                    ),
                   ),
-                  const SizedBox(height: 80),
-                ],
+                ),
+                items: getTransactionTypes()
+                    .map((e) => DropdownMenuItem(
+                          value: e,
+                          child: Text(e),
+                        ))
+                    .toList(),
+                onChanged: (v) => controller.type.value = v,
               ),
-            ),
-            if (controller.isLoading.value)
-              const Center(child: CircularProgressIndicator()),
-          ],
+              AppTextFromField(
+                controller: controller.amount,
+                label: 'পরিমাণ',
+                hintText: 'পরিমাণ লিখুন',
+                prefixIcon: Icons.money,
+                keyboardType: TextInputType.number,
+              ),
+              DropdownButtonFormField<String>(
+                value: controller.paymentMethod.value,
+                isExpanded: true,
+                borderRadius: BorderRadius.circular(12),
+                menuMaxHeight: 320,
+                icon: const Icon(Icons.keyboard_arrow_down_rounded),
+                decoration: InputDecoration(
+                  labelText: 'পেমেন্ট পদ্ধতি',
+                  hintText: 'পেমেন্ট পদ্ধতি নির্বাচন করুন',
+                  prefixIcon: const Icon(Icons.payment),
+                  filled: true,
+                  fillColor: Theme.of(context)
+                      .colorScheme
+                      .surface
+                      .withOpacity(0.7),
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: Theme.of(context).colorScheme.outlineVariant,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: Theme.of(context).colorScheme.primary,
+                      width: 1.4,
+                    ),
+                  ),
+                ),
+                items: paymentMethods
+                    .map((e) => DropdownMenuItem(
+                          value: e,
+                          child: Text(e),
+                        ))
+                    .toList(),
+                onChanged: (v) => controller.paymentMethod.value = v,
+              ),
+              AppTextFromField(
+                controller: controller.note,
+                label: 'নোট',
+                hintText: 'নোট লিখুন',
+                prefixIcon: Icons.note,
+                isMaxLines: 3,
+              ),
+              const SizedBox(height: 80),
+            ],
+          ),
         );
       }),
       bottomNavigationBar: Obx(() => SafeArea(
@@ -138,8 +133,49 @@ class AddTransactionScreen extends StatelessWidget {
               padding: const EdgeInsets.all(16),
               child: AppButton(
                 label: 'সেভ করুন',
+                isLoading: controller.isLoading.value,
                 onPressed: controller.enableBtn.value
-                    ? controller.addTransaction
+                    ? () {
+                        PanaraConfirmDialog.show(
+                          context,
+                          title: 'নিশ্চিত করুন',
+                          message: 'লেনদেন যুক্ত করতে চান?',
+                          confirmButtonText: 'হ্যাঁ',
+                          cancelButtonText: 'না',
+                          onTapCancel: () {
+                            Navigator.of(context).pop();
+                          },
+                          onTapConfirm: () async {
+                            Navigator.of(context).pop();
+                            final success = await controller.addTransaction();
+                            if (success) {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'সফল হয়েছে',
+                                message: 'লেনদেন যুক্ত করা হয়েছে',
+                                panaraDialogType: PanaraDialogType.success,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                  Get.back();
+                                },
+                              );
+                            } else {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'ত্রুটি',
+                                message: 'লেনদেন যুক্ত করতে ব্যর্থ হয়েছে',
+                                panaraDialogType: PanaraDialogType.error,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                },
+                              );
+                            }
+                          },
+                          panaraDialogType: PanaraDialogType.normal,
+                        );
+                      }
                     : null,
               ),
             ),

--- a/lib/modules/accounts/screens/edit_transaction_screen.dart
+++ b/lib/modules/accounts/screens/edit_transaction_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
@@ -20,13 +21,11 @@ class EditTransactionScreen extends StatelessWidget {
         title: const Text('লেনদেন আপডেট করুন'),
       ),
       body: Obx(() {
-        return Stack(
-          children: [
-            SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                spacing: 16,
-                children: [
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            spacing: 16,
+            children: [
                   DropdownButtonFormField<String>(
                     value: controller.type.value,
                     isExpanded: true,
@@ -123,29 +122,64 @@ class EditTransactionScreen extends StatelessWidget {
                     prefixIcon: Icons.note,
                     isMaxLines: 3,
                   ),
-                  const SizedBox(height: 80),
-                ],
-              ),
-            ),
-            if (controller.isLoading.value)
-              const Center(child: CircularProgressIndicator()),
-          ],
+              const SizedBox(height: 80),
+            ],
+          ),
         );
       }),
-      bottomNavigationBar: Obx(
-        () => SafeArea(
-          top: false,
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: AppButton(
-              label: 'আপডেট করুন',
-              onPressed: controller.enableBtn.value
-                  ? controller.updateTransaction
-                  : null,
+      bottomNavigationBar: Obx(() => SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: AppButton(
+                label: 'আপডেট করুন',
+                isLoading: controller.isLoading.value,
+                onPressed: controller.enableBtn.value
+                    ? () {
+                        PanaraConfirmDialog.show(
+                          context,
+                          title: 'নিশ্চিত করুন',
+                          message: 'লেনদেন আপডেট করতে চান?',
+                          confirmButtonText: 'হ্যাঁ',
+                          cancelButtonText: 'না',
+                          onTapCancel: () {
+                            Navigator.of(context).pop();
+                          },
+                          onTapConfirm: () async {
+                            Navigator.of(context).pop();
+                            final success = await controller.updateTransaction();
+                            if (success) {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'সফল হয়েছে',
+                                message: 'লেনদেন আপডেট করা হয়েছে',
+                                panaraDialogType: PanaraDialogType.success,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                  Get.back();
+                                },
+                              );
+                            } else {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'ত্রুটি',
+                                message: 'লেনদেন আপডেট করতে ব্যর্থ হয়েছে',
+                                panaraDialogType: PanaraDialogType.error,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                },
+                              );
+                            }
+                          },
+                          panaraDialogType: PanaraDialogType.normal,
+                        );
+                      }
+                    : null,
+              ),
             ),
-          ),
-        ),
-      ),
+          )),
     );
   }
 }

--- a/lib/modules/case/controllers/add_case_controller.dart
+++ b/lib/modules/case/controllers/add_case_controller.dart
@@ -28,6 +28,8 @@ class AddCaseController extends GetxController {
   final parties = <Party>[].obs;
   final caseTypes = ['Civil', 'Criminal', 'Family', 'Other'];
 
+  final RxBool isLoading = false.obs;
+
   @override
   void onInit() {
     super.onInit();
@@ -39,32 +41,38 @@ class AddCaseController extends GetxController {
     }
   }
 
-  Future<void> addCase() async {
+  Future<bool> addCase() async {
     final user = AppFirebase().currentUser;
-    if (user == null) return;
+    if (user == null || isLoading.value) return false;
+    try {
+      isLoading.value = true;
+      final caseModel = CourtCase(
+        docId: '',
+        caseType: selectedCaseType.value ?? '',
+        caseTitle: caseTitle.text.trim(),
+        courtName: courtName.text.trim(),
+        caseNumber: caseNumber.text.trim(),
+        filedDate: Timestamp.fromDate(filedDate.value ?? DateTime.now()),
+        caseStatus: caseStatus.text.trim(),
+        plaintiff: selectedPlaintiff.value!,
+        defendant: selectedDefendant.value!,
+        hearingDates: hearingDate.value != null
+            ? [Timestamp.fromDate(hearingDate.value!)]
+            : <Timestamp>[],
+        judgeName: judgeName.text.trim(),
+        documentsAttached:
+            document.text.isNotEmpty ? [document.text.trim()] : <String>[],
+        courtOrders:
+            courtOrder.text.isNotEmpty ? [courtOrder.text.trim()] : <String>[],
+        caseSummary: caseSummary.text.trim(),
+      );
 
-    final caseModel = CourtCase(
-      docId: '',
-      caseType: selectedCaseType.value ?? '',
-      caseTitle: caseTitle.text.trim(),
-      courtName: courtName.text.trim(),
-      caseNumber: caseNumber.text.trim(),
-      filedDate: Timestamp.fromDate(filedDate.value ?? DateTime.now()),
-      caseStatus: caseStatus.text.trim(),
-      plaintiff: selectedPlaintiff.value!,
-      defendant: selectedDefendant.value!,
-      hearingDates: hearingDate.value != null
-          ? [Timestamp.fromDate(hearingDate.value!)]
-          : <Timestamp>[],
-      judgeName: judgeName.text.trim(),
-      documentsAttached:
-          document.text.isNotEmpty ? [document.text.trim()] : <String>[],
-      courtOrders:
-          courtOrder.text.isNotEmpty ? [courtOrder.text.trim()] : <String>[],
-      caseSummary: caseSummary.text.trim(),
-    );
-
-    await CaseService.addCase(caseModel, user.uid);
-    Get.back();
+      await CaseService.addCase(caseModel, user.uid);
+      return true;
+    } catch (e) {
+      return false;
+    } finally {
+      isLoading.value = false;
+    }
   }
 }

--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -1,6 +1,7 @@
 import '../../../widgets/dynamic_multi_step_form.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 import '../controllers/add_case_controller.dart';
 import '../../../models/party.dart';
@@ -41,8 +42,8 @@ class AddCaseScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Add Case')),
-      body: DynamicMultiStepForm(
-        steps: [
+      body: Obx(() => DynamicMultiStepForm(
+            steps: [
           FormStep(
             title: const Text('Case Info'),
             content: Column(
@@ -137,9 +138,50 @@ class AddCaseScreen extends StatelessWidget {
               ],
             ),
           ),
-        ],
-        onSubmit: controller.addCase,
-      ),
+            ],
+            isLoading: controller.isLoading.value,
+            onSubmit: () {
+              PanaraConfirmDialog.show(
+                context,
+                title: 'নিশ্চিত করুন',
+                message: 'কেস যুক্ত করতে চান?',
+                confirmButtonText: 'হ্যাঁ',
+                cancelButtonText: 'না',
+                onTapCancel: () {
+                  Navigator.of(context).pop();
+                },
+                onTapConfirm: () async {
+                  Navigator.of(context).pop();
+                  final success = await controller.addCase();
+                  if (success) {
+                    PanaraInfoDialog.show(
+                      context,
+                      title: 'সফল হয়েছে',
+                      message: 'কেস যুক্ত করা হয়েছে',
+                      panaraDialogType: PanaraDialogType.success,
+                      barrierDismissible: false,
+                      onTapDismiss: () {
+                        Navigator.of(context).pop();
+                        Get.back();
+                      },
+                    );
+                  } else {
+                    PanaraInfoDialog.show(
+                      context,
+                      title: 'ত্রুটি',
+                      message: 'কেস যুক্ত করতে ব্যর্থ হয়েছে',
+                      panaraDialogType: PanaraDialogType.error,
+                      barrierDismissible: false,
+                      onTapDismiss: () {
+                        Navigator.of(context).pop();
+                      },
+                    );
+                  }
+                },
+                panaraDialogType: PanaraDialogType.normal,
+              );
+            },
+          )),
     );
   }
 }

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -1,6 +1,7 @@
 import '../../../widgets/dynamic_multi_step_form.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 import '../../../models/court_case.dart';
 import '../../../models/party.dart';
@@ -44,8 +45,8 @@ class EditCaseScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Edit Case')),
-      body: DynamicMultiStepForm(
-        steps: [
+      body: Obx(() => DynamicMultiStepForm(
+            steps: [
           FormStep(
             title: const Text('Case Info'),
             content: Column(
@@ -140,9 +141,50 @@ class EditCaseScreen extends StatelessWidget {
               ],
             ),
           ),
-        ],
-        onSubmit: controller.updateCase,
-      ),
+            ],
+            isLoading: controller.isLoading.value,
+            onSubmit: () {
+              PanaraConfirmDialog.show(
+                context,
+                title: 'নিশ্চিত করুন',
+                message: 'কেস আপডেট করতে চান?',
+                confirmButtonText: 'হ্যাঁ',
+                cancelButtonText: 'না',
+                onTapCancel: () {
+                  Navigator.of(context).pop();
+                },
+                onTapConfirm: () async {
+                  Navigator.of(context).pop();
+                  final success = await controller.updateCase();
+                  if (success) {
+                    PanaraInfoDialog.show(
+                      context,
+                      title: 'সফল হয়েছে',
+                      message: 'কেস আপডেট করা হয়েছে',
+                      panaraDialogType: PanaraDialogType.success,
+                      barrierDismissible: false,
+                      onTapDismiss: () {
+                        Navigator.of(context).pop();
+                        Get.back();
+                      },
+                    );
+                  } else {
+                    PanaraInfoDialog.show(
+                      context,
+                      title: 'ত্রুটি',
+                      message: 'কেস আপডেট করতে ব্যর্থ হয়েছে',
+                      panaraDialogType: PanaraDialogType.error,
+                      barrierDismissible: false,
+                      onTapDismiss: () {
+                        Navigator.of(context).pop();
+                      },
+                    );
+                  }
+                },
+                panaraDialogType: PanaraDialogType.normal,
+              );
+            },
+          )),
     );
   }
 }

--- a/lib/modules/party/controllers/add_party_controller.dart
+++ b/lib/modules/party/controllers/add_party_controller.dart
@@ -122,9 +122,9 @@ class AddPartyController extends GetxController {
     }
   }
 
-  Future<void> addParty() async {
-    if (!enableBtn.value || isLoading.value) return;
-    if (!ActivationGuard.check()) return;
+  Future<bool> addParty() async {
+    if (!enableBtn.value || isLoading.value) return false;
+    if (!ActivationGuard.check()) return false;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;
@@ -146,21 +146,9 @@ class AddPartyController extends GetxController {
       );
 
       await PartyService.addParty(party);
-
-      Get.back();
-      Get.snackbar(
-        'সফল হয়েছে',
-        'পক্ষ যুক্ত করা হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.green,
-      );
+      return true;
     } catch (e) {
-      Get.snackbar(
-        'ত্রুটি',
-        'পক্ষ যুক্ত করতে ব্যর্থ হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.red,
-      );
+      return false;
     } finally {
       isLoading.value = false;
     }

--- a/lib/modules/party/controllers/edit_party_controller.dart
+++ b/lib/modules/party/controllers/edit_party_controller.dart
@@ -129,9 +129,9 @@ class EditPartyController extends GetxController {
     }
   }
 
-  Future<void> updateParty() async {
-    if (!enableBtn.value || isLoading.value) return;
-    if (!ActivationGuard.check()) return;
+  Future<bool> updateParty() async {
+    if (!enableBtn.value || isLoading.value) return false;
+    if (!ActivationGuard.check()) return false;
     try {
       isLoading.value = true;
       final user = AppFirebase().currentUser;
@@ -154,21 +154,9 @@ class EditPartyController extends GetxController {
       );
 
       await PartyService.updateParty(updated);
-
-      Get.back();
-      Get.snackbar(
-        'সফল হয়েছে',
-        'পক্ষ আপডেট করা হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.green,
-      );
+      return true;
     } catch (e) {
-      Get.snackbar(
-        'ত্রুটি',
-        'পক্ষ আপডেট করতে ব্যর্থ হয়েছে',
-        backgroundColor: Colors.white,
-        colorText: Colors.red,
-      );
+      return false;
     } finally {
       isLoading.value = false;
     }

--- a/lib/modules/party/screens/add_party_screen.dart
+++ b/lib/modules/party/screens/add_party_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
@@ -18,54 +19,47 @@ class AddPartyScreen extends StatelessWidget {
         title: const Text('নতুন পক্ষ যুক্ত করুন'),
       ),
       body: Obx(() {
-        return Stack(
-          children: [
-            SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                spacing: 16,
-                children: [
-                  GestureDetector(
-                    onTap: controller.showImagePicker,
-                    child: Obx(() {
-                      final image = controller.photo.value;
-                      return CircleAvatar(
-                        radius: 50,
-                        backgroundImage:
-                            image != null ? FileImage(File(image.path)) : null,
-                        child: image == null
-                            ? const Icon(Icons.camera_alt, size: 40)
-                            : null,
-                      );
-                    }),
-                  ),
-                  AppTextFromField(
-                    controller: controller.name,
-                    label: 'নাম',
-                    hintText: 'পক্ষের নাম লিখুন',
-                    prefixIcon: Icons.person,
-                  ),
-                  AppTextFromField(
-                    controller: controller.phone,
-                    label: 'মোবাইল',
-                    hintText: 'মোবাইল নম্বর লিখুন',
-                    prefixIcon: Icons.phone,
-                    keyboardType: TextInputType.phone,
-                  ),
-                  AppTextFromField(
-                    controller: controller.address,
-                    label: 'ঠিকানা',
-                    hintText: 'ঠিকানা লিখুন',
-                    prefixIcon: Icons.home,
-                    isMaxLines: 3,
-                  ),
-                  const SizedBox(height: 20),
-                ],
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            spacing: 16,
+            children: [
+              GestureDetector(
+                onTap: controller.showImagePicker,
+                child: Obx(() {
+                  final image = controller.photo.value;
+                  return CircleAvatar(
+                    radius: 50,
+                    backgroundImage:
+                        image != null ? FileImage(File(image.path)) : null,
+                    child:
+                        image == null ? const Icon(Icons.camera_alt, size: 40) : null,
+                  );
+                }),
               ),
-            ),
-            if (controller.isLoading.value)
-              const Center(child: CircularProgressIndicator()),
-          ],
+              AppTextFromField(
+                controller: controller.name,
+                label: 'নাম',
+                hintText: 'পক্ষের নাম লিখুন',
+                prefixIcon: Icons.person,
+              ),
+              AppTextFromField(
+                controller: controller.phone,
+                label: 'মোবাইল',
+                hintText: 'মোবাইল নম্বর লিখুন',
+                prefixIcon: Icons.phone,
+                keyboardType: TextInputType.phone,
+              ),
+              AppTextFromField(
+                controller: controller.address,
+                label: 'ঠিকানা',
+                hintText: 'ঠিকানা লিখুন',
+                prefixIcon: Icons.home,
+                isMaxLines: 3,
+              ),
+              const SizedBox(height: 20),
+            ],
+          ),
         );
       }),
       bottomNavigationBar: Obx(() => SafeArea(
@@ -74,8 +68,50 @@ class AddPartyScreen extends StatelessWidget {
               padding: const EdgeInsets.all(16),
               child: AppButton(
                 label: 'সেভ করুন',
-                onPressed:
-                    controller.enableBtn.value ? controller.addParty : null,
+                isLoading: controller.isLoading.value,
+                onPressed: controller.enableBtn.value
+                    ? () {
+                        PanaraConfirmDialog.show(
+                          context,
+                          title: 'নিশ্চিত করুন',
+                          message: 'পক্ষ যুক্ত করতে চান?',
+                          confirmButtonText: 'হ্যাঁ',
+                          cancelButtonText: 'না',
+                          onTapCancel: () {
+                            Navigator.of(context).pop();
+                          },
+                          onTapConfirm: () async {
+                            Navigator.of(context).pop();
+                            final success = await controller.addParty();
+                            if (success) {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'সফল হয়েছে',
+                                message: 'পক্ষ যুক্ত করা হয়েছে',
+                                panaraDialogType: PanaraDialogType.success,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                  Get.back();
+                                },
+                              );
+                            } else {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'ত্রুটি',
+                                message: 'পক্ষ যুক্ত করতে ব্যর্থ হয়েছে',
+                                panaraDialogType: PanaraDialogType.error,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                },
+                              );
+                            }
+                          },
+                          panaraDialogType: PanaraDialogType.normal,
+                        );
+                      }
+                    : null,
               ),
             ),
           )),

--- a/lib/modules/party/screens/edit_party_screen.dart
+++ b/lib/modules/party/screens/edit_party_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_text_from_field.dart';
@@ -20,57 +21,51 @@ class EditPartyScreen extends StatelessWidget {
         title: const Text('পক্ষ সম্পাদনা'),
       ),
       body: Obx(() {
-        return Stack(
-          children: [
-            SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                spacing: 16,
-                children: [
-                  GestureDetector(
-                    onTap: controller.showImagePicker,
-                    child: Obx(() {
-                      final image = controller.photo.value;
-                      return CircleAvatar(
-                        radius: 50,
-                        backgroundImage: image != null
-                            ? FileImage(File(image.path))
-                            : (party.photoUrl != null
-                                ? NetworkImage(party.photoUrl!) as ImageProvider
-                                : null),
-                        child: image == null && party.photoUrl == null
-                            ? const Icon(Icons.camera_alt, size: 40)
-                            : null,
-                      );
-                    }),
-                  ),
-                  AppTextFromField(
-                    controller: controller.name,
-                    label: 'নাম',
-                    hintText: 'পক্ষের নাম লিখুন',
-                    prefixIcon: Icons.person,
-                  ),
-                  AppTextFromField(
-                    controller: controller.phone,
-                    label: 'মোবাইল',
-                    hintText: 'মোবাইল নম্বর লিখুন',
-                    prefixIcon: Icons.phone,
-                    keyboardType: TextInputType.phone,
-                  ),
-                  AppTextFromField(
-                    controller: controller.address,
-                    label: 'ঠিকানা',
-                    hintText: 'ঠিকানা লিখুন',
-                    prefixIcon: Icons.home,
-                    isMaxLines: 3,
-                  ),
-                  const SizedBox(height: 20),
-                ],
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            spacing: 16,
+            children: [
+              GestureDetector(
+                onTap: controller.showImagePicker,
+                child: Obx(() {
+                  final image = controller.photo.value;
+                  return CircleAvatar(
+                    radius: 50,
+                    backgroundImage: image != null
+                        ? FileImage(File(image.path))
+                        : (party.photoUrl != null
+                            ? NetworkImage(party.photoUrl!) as ImageProvider
+                            : null),
+                    child: image == null && party.photoUrl == null
+                        ? const Icon(Icons.camera_alt, size: 40)
+                        : null,
+                  );
+                }),
               ),
-            ),
-            if (controller.isLoading.value)
-              const Center(child: CircularProgressIndicator()),
-          ],
+              AppTextFromField(
+                controller: controller.name,
+                label: 'নাম',
+                hintText: 'পক্ষের নাম লিখুন',
+                prefixIcon: Icons.person,
+              ),
+              AppTextFromField(
+                controller: controller.phone,
+                label: 'মোবাইল',
+                hintText: 'মোবাইল নম্বর লিখুন',
+                prefixIcon: Icons.phone,
+                keyboardType: TextInputType.phone,
+              ),
+              AppTextFromField(
+                controller: controller.address,
+                label: 'ঠিকানা',
+                hintText: 'ঠিকানা লিখুন',
+                prefixIcon: Icons.home,
+                isMaxLines: 3,
+              ),
+              const SizedBox(height: 20),
+            ],
+          ),
         );
       }),
       bottomNavigationBar: Obx(() => SafeArea(
@@ -79,8 +74,49 @@ class EditPartyScreen extends StatelessWidget {
               padding: const EdgeInsets.all(16),
               child: AppButton(
                 label: 'আপডেট করুন',
+                isLoading: controller.isLoading.value,
                 onPressed: controller.enableBtn.value
-                    ? controller.updateParty
+                    ? () {
+                        PanaraConfirmDialog.show(
+                          context,
+                          title: 'নিশ্চিত করুন',
+                          message: 'পক্ষ আপডেট করতে চান?',
+                          confirmButtonText: 'হ্যাঁ',
+                          cancelButtonText: 'না',
+                          onTapCancel: () {
+                            Navigator.of(context).pop();
+                          },
+                          onTapConfirm: () async {
+                            Navigator.of(context).pop();
+                            final success = await controller.updateParty();
+                            if (success) {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'সফল হয়েছে',
+                                message: 'পক্ষ আপডেট করা হয়েছে',
+                                panaraDialogType: PanaraDialogType.success,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                  Get.back();
+                                },
+                              );
+                            } else {
+                              PanaraInfoDialog.show(
+                                context,
+                                title: 'ত্রুটি',
+                                message: 'পক্ষ আপডেট করতে ব্যর্থ হয়েছে',
+                                panaraDialogType: PanaraDialogType.error,
+                                barrierDismissible: false,
+                                onTapDismiss: () {
+                                  Navigator.of(context).pop();
+                                },
+                              );
+                            }
+                          },
+                          panaraDialogType: PanaraDialogType.normal,
+                        );
+                      }
                     : null,
               ),
             ),

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -1,15 +1,22 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:simple_shadow/simple_shadow.dart';
 
 class AppButton extends StatelessWidget {
   final String label;
   final Function()? onPressed;
+  final bool isLoading;
 
-  const AppButton({super.key, required this.label, required this.onPressed});
+  const AppButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.isLoading = false,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final isEnabled = onPressed != null;
+    final isEnabled = onPressed != null && !isLoading;
 
     return SimpleShadow(
       opacity: isEnabled ? 0.3 : 0, // shadow only if enabled
@@ -23,14 +30,16 @@ class AppButton extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
           ),
           child: Center(
-            child: Text(
-              label,
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                color: isEnabled ? Colors.white : Colors.white70,
-              ),
-            ),
+            child: isLoading
+                ? const CupertinoActivityIndicator(color: Colors.white)
+                : Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: isEnabled ? Colors.white : Colors.white70,
+                    ),
+                  ),
           ),
         ),
       ),

--- a/lib/widgets/dynamic_multi_step_form.dart
+++ b/lib/widgets/dynamic_multi_step_form.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 /// Represents a single step in [DynamicMultiStepForm].
@@ -16,13 +17,21 @@ class FormStep {
 /// Displays a simple [Stepper] with next/back navigation and calls
 /// [onSubmit] when the last step is completed.
 class DynamicMultiStepForm extends StatefulWidget {
-  const DynamicMultiStepForm({super.key, required this.steps, required this.onSubmit});
+  const DynamicMultiStepForm({
+    super.key,
+    required this.steps,
+    required this.onSubmit,
+    this.isLoading = false,
+  });
 
   /// Ordered list of form steps.
   final List<FormStep> steps;
 
   /// Callback invoked when the final step is submitted.
   final VoidCallback onSubmit;
+
+  /// Whether a submit operation is in progress.
+  final bool isLoading;
 
   @override
   State<DynamicMultiStepForm> createState() => _DynamicMultiStepFormState();
@@ -32,6 +41,7 @@ class _DynamicMultiStepFormState extends State<DynamicMultiStepForm> {
   int _currentStep = 0;
 
   void _next() {
+    if (widget.isLoading) return;
     if (_currentStep < widget.steps.length - 1) {
       setState(() => _currentStep++);
     } else {
@@ -60,8 +70,10 @@ class _DynamicMultiStepFormState extends State<DynamicMultiStepForm> {
               TextButton(onPressed: _back, child: const Text('Back')),
             const SizedBox(width: 8),
             ElevatedButton(
-              onPressed: _next,
-              child: Text(isLast ? 'Submit' : 'Next'),
+              onPressed: widget.isLoading ? null : _next,
+              child: widget.isLoading && isLast
+                  ? const CupertinoActivityIndicator()
+                  : Text(isLast ? 'Submit' : 'Next'),
             ),
           ],
         );


### PR DESCRIPTION
## Summary
- add loading state to AppButton using CupertinoActivityIndicator
- prompt for confirmation and show success/error dialogs on add/edit forms
- disable submit in multi-step forms while processing

## Testing
- `flutter format lib/modules lib/widgets` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f575df883308595ce233f7834dc