### PR TITLE
Make CourtCase docId optional

### DIFF
--- a/lib/models/court_case.dart
+++ b/lib/models/court_case.dart
@@ -3,7 +3,7 @@ import 'party.dart';
 
 class CourtCase {
   // docId: Frontend unique identifier (only used in the frontend)
-  String docId;
+  String? docId;
 
   // Case Information
   String caseType;
@@ -34,7 +34,7 @@ class CourtCase {
 
   // Constructor
   CourtCase({
-    required this.docId,
+    this.docId,
     required this.caseType,
     required this.caseTitle,
     required this.courtName,
@@ -53,7 +53,6 @@ class CourtCase {
   // Method to convert the case data to a map (for Firebase storage)
   Map<String, dynamic> toMap() {
     return {
-      'docId': docId,  // Store docId in Firestore
       'caseType': caseType,
       'caseTitle': caseTitle,
       'courtName': courtName,
@@ -71,9 +70,9 @@ class CourtCase {
   }
 
   // Method to convert a map to a CourtCase object (for fetching data from Firebase)
-  factory CourtCase.fromMap(Map<String, dynamic> map) {
+  factory CourtCase.fromMap(Map<String, dynamic> map, {String? docId}) {
     return CourtCase(
-      docId: map['docId'],  // docId is fetched directly from Firestore
+      docId: docId,
       caseType: map['caseType'],
       caseTitle: map['caseTitle'],
       courtName: map['courtName'],

--- a/lib/modules/case/controllers/add_case_controller.dart
+++ b/lib/modules/case/controllers/add_case_controller.dart
@@ -47,7 +47,6 @@ class AddCaseController extends GetxController {
     try {
       isLoading.value = true;
       final caseModel = CourtCase(
-        docId: '',
         caseType: selectedCaseType.value ?? '',
         caseTitle: caseTitle.text.trim(),
         courtName: courtName.text.trim(),

--- a/lib/modules/case/services/case_service.dart
+++ b/lib/modules/case/services/case_service.dart
@@ -17,7 +17,7 @@ class CaseService {
 
   static Future<void> updateCase(CourtCase courtCase, String userId) async {
     final docId = courtCase.docId;
-    if (docId.isEmpty) {
+    if (docId == null || docId.isEmpty) {
       throw Exception('Case document ID is required for update');
     }
     await _firestore
@@ -35,7 +35,7 @@ class CaseService {
         .collection(AppCollections.cases)
         .snapshots()
         .map((snapshot) => snapshot.docs
-            .map((doc) => CourtCase.fromMap(doc.data()))
+            .map((doc) => CourtCase.fromMap(doc.data(), docId: doc.id))
             .toList());
   }
 

--- a/lib/modules/case/widgets/case_tile.dart
+++ b/lib/modules/case/widgets/case_tile.dart
@@ -21,7 +21,12 @@ class CaseTile extends StatelessWidget {
       },
       trailing: IconButton(
         icon: const Icon(Icons.delete_outline),
-        onPressed: () => controller.deleteCase(caseItem.docId),
+        onPressed: () {
+          final id = caseItem.docId;
+          if (id != null) {
+            controller.deleteCase(id);
+          }
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Make CourtCase docId nullable and remove it from Firestore mappings
- Update case service and controllers to handle optional docId
- Guard delete action against null docId in case tiles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34abe1ad88330ac257536c7814ffe