### PR TITLE
fix: reset controllers before add/edit party

### DIFF
--- a/lib/modules/party/screens/add_party_screen.dart
+++ b/lib/modules/party/screens/add_party_screen.dart
@@ -13,6 +13,9 @@ class AddPartyScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (Get.isRegistered<AddPartyController>()) {
+      Get.delete<AddPartyController>();
+    }
     final controller = Get.put(AddPartyController());
     return Scaffold(
       appBar: AppBar(

--- a/lib/modules/party/screens/edit_party_screen.dart
+++ b/lib/modules/party/screens/edit_party_screen.dart
@@ -15,6 +15,9 @@ class EditPartyScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (Get.isRegistered<EditPartyController>()) {
+      Get.delete<EditPartyController>();
+    }
     final controller = Get.put(EditPartyController(party));
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary
- ensure AddPartyController is deleted before reusing AddPartyScreen
- ensure EditPartyController is deleted before reusing EditPartyScreen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35689ff748330b3cce5321197a071