### PR TITLE
feat: enhance case list with filters and search

### DIFF
--- a/lib/modules/case/controllers/case_controller.dart
+++ b/lib/modules/case/controllers/case_controller.dart
@@ -7,6 +7,71 @@ import '../services/case_service.dart';
 class CaseController extends GetxController {
   final cases = <CourtCase>[].obs;
   final isLoading = true.obs;
+  final selectedFilter = 'today'.obs;
+
+  DateTime? _nextDate(CourtCase c) {
+    if (c.hearingDates.isEmpty) return null;
+    return c.hearingDates.first.toDate();
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  List<CourtCase> get todayCases {
+    final now = DateTime.now();
+    return cases.where((c) {
+      final d = _nextDate(c);
+      if (d == null) return false;
+      return _isSameDay(d, now);
+    }).toList();
+  }
+
+  List<CourtCase> get tomorrowCases {
+    final now = DateTime.now().add(const Duration(days: 1));
+    return cases.where((c) {
+      final d = _nextDate(c);
+      if (d == null) return false;
+      return _isSameDay(d, now);
+    }).toList();
+  }
+
+  List<CourtCase> get weekCases {
+    final now = DateTime.now();
+    final startOfWeek = now.subtract(Duration(days: now.weekday - 1));
+    final endOfWeek = startOfWeek.add(const Duration(days: 6));
+    return cases.where((c) {
+      final d = _nextDate(c);
+      if (d == null) return false;
+      return !d.isBefore(startOfWeek) && !d.isAfter(endOfWeek);
+    }).toList();
+  }
+
+  List<CourtCase> get monthCases {
+    final now = DateTime.now();
+    return cases.where((c) {
+      final d = _nextDate(c);
+      if (d == null) return false;
+      return d.year == now.year && d.month == now.month;
+    }).toList();
+  }
+
+  List<CourtCase> get filteredCases {
+    switch (selectedFilter.value) {
+      case 'tomorrow':
+        return tomorrowCases;
+      case 'week':
+        return weekCases;
+      case 'month':
+        return monthCases;
+      default:
+        return todayCases;
+    }
+  }
+
+  int get todayCount => todayCases.length;
+  int get tomorrowCount => tomorrowCases.length;
+  int get weekCount => weekCases.length;
+  int get monthCount => monthCases.length;
 
   @override
   void onInit() {

--- a/lib/modules/case/screens/case_detail_screen.dart
+++ b/lib/modules/case/screens/case_detail_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../models/court_case.dart';
+import '../controllers/case_controller.dart';
+import 'edit_case_screen.dart';
+
+class CaseDetailScreen extends StatelessWidget {
+  const CaseDetailScreen(this.caseItem, {super.key});
+
+  final CourtCase caseItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CaseController>();
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(caseItem.caseTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: () {
+              Get.to(() => EditCaseScreen(caseItem));
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            onPressed: () {
+              final id = caseItem.docId;
+              if (id != null) {
+                controller.deleteCase(id);
+                Get.back();
+              }
+            },
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Case Number: ${caseItem.caseNumber}'),
+            const SizedBox(height: 8),
+            Text('Status: ${caseItem.caseStatus}'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/case/screens/case_screen.dart
+++ b/lib/modules/case/screens/case_screen.dart
@@ -3,32 +3,74 @@ import 'package:get/get.dart';
 
 import '../controllers/case_controller.dart';
 import '../widgets/case_tile.dart';
-import 'add_case_screen.dart';
 
 class CaseScreen extends StatelessWidget {
   const CaseScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.put(CaseController());
-    return Scaffold(
-      appBar: AppBar(title: const Text('Cases')),
-      body: Obx(() {
-        if (controller.isLoading.value) {
-          return const Center(child: CircularProgressIndicator());
-        }
-        if (controller.cases.isEmpty) {
-          return const Center(child: Text('No cases found'));
-        }
-        return ListView.builder(
-          itemCount: controller.cases.length,
-          itemBuilder: (_, i) => CaseTile(caseItem: controller.cases[i]),
-        );
-      }),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => Get.to(() => const AddCaseScreen()),
-        child: const Icon(Icons.add),
-      ),
-    );
+    final controller = Get.find<CaseController>();
+    return Obx(() {
+      if (controller.isLoading.value) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      if (controller.cases.isEmpty) {
+        return const Center(child: Text('No cases found'));
+      }
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Text(
+              'Your Cases',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+          ),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                filterChip('today', "Today's (${controller.todayCount})", controller),
+                filterChip('tomorrow', 'Tomorrow (${controller.tomorrowCount})', controller),
+                filterChip('week', 'This Week (${controller.weekCount})', controller),
+                filterChip('month', 'This Month (${controller.monthCount})', controller),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: ListView.builder(
+                key: ValueKey(controller.selectedFilter.value),
+                itemCount: controller.filteredCases.length,
+                itemBuilder: (_, i) {
+                  final caseItem = controller.filteredCases[i];
+                  return TweenAnimationBuilder<double>(
+                    tween: Tween(begin: 0, end: 1),
+                    duration: const Duration(milliseconds: 300),
+                    builder: (context, value, child) =>
+                        Opacity(opacity: value, child: child),
+                    child: CaseTile(caseItem: caseItem),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      );
+    });
   }
+}
+
+Widget filterChip(String key, String label, CaseController controller) {
+  return Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 4),
+    child: ChoiceChip(
+      label: Text(label),
+      selected: controller.selectedFilter.value == key,
+      onSelected: (_) => controller.selectedFilter.value = key,
+    ),
+  );
 }

--- a/lib/modules/case/screens/case_search_screen.dart
+++ b/lib/modules/case/screens/case_search_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/case_controller.dart';
+import '../widgets/case_tile.dart';
+
+class CaseSearchScreen extends StatelessWidget {
+  CaseSearchScreen({super.key});
+
+  final query = ''.obs;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CaseController>();
+    return Scaffold(
+      appBar: AppBar(
+        title: TextField(
+          autofocus: true,
+          decoration: const InputDecoration(
+            hintText: 'Search cases',
+            border: InputBorder.none,
+          ),
+          onChanged: (v) => query.value = v.toLowerCase(),
+        ),
+      ),
+      body: Obx(() {
+        final q = query.value;
+        final results = controller.cases.where((c) {
+          final title = c.caseTitle.toLowerCase();
+          final number = c.caseNumber.toLowerCase();
+          final plaintiff = c.plaintiff.name.toLowerCase();
+          final defendant = c.defendant.name.toLowerCase();
+          return title.contains(q) ||
+              number.contains(q) ||
+              plaintiff.contains(q) ||
+              defendant.contains(q);
+        }).toList();
+        return ListView.builder(
+          itemCount: results.length,
+          itemBuilder: (_, i) => CaseTile(caseItem: results[i]),
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/case/widgets/case_tile.dart
+++ b/lib/modules/case/widgets/case_tile.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../models/court_case.dart';
-import '../controllers/case_controller.dart';
-import '../screens/edit_case_screen.dart';
+import '../screens/case_detail_screen.dart';
 
 class CaseTile extends StatelessWidget {
   const CaseTile({super.key, required this.caseItem});
@@ -12,22 +11,12 @@ class CaseTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.find<CaseController>();
     return ListTile(
       title: Text(caseItem.caseTitle),
       subtitle: Text(caseItem.caseNumber),
       onTap: () {
-        Get.to(() => EditCaseScreen(caseItem));
+        Get.to(() => CaseDetailScreen(caseItem));
       },
-      trailing: IconButton(
-        icon: const Icon(Icons.delete_outline),
-        onPressed: () {
-          final id = caseItem.docId;
-          if (id != null) {
-            controller.deleteCase(id);
-          }
-        },
-      ),
     );
   }
 }

--- a/lib/modules/layout/screens/layout_screen.dart
+++ b/lib/modules/layout/screens/layout_screen.dart
@@ -1,5 +1,8 @@
 import 'package:courtdiary/modules/accounts/screens/accounts_screen.dart';
+import 'package:courtdiary/modules/case/controllers/case_controller.dart';
+import 'package:courtdiary/modules/case/screens/add_case_screen.dart';
 import 'package:courtdiary/modules/case/screens/case_screen.dart';
+import 'package:courtdiary/modules/case/screens/case_search_screen.dart';
 import 'package:courtdiary/themes/theme_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -19,6 +22,7 @@ class LayoutScreen extends StatelessWidget {
   LayoutScreen({super.key});
   final themeController = Get.find<ThemeController>();
   final layoutController = Get.put(LayoutController());
+  final _caseController = Get.put(CaseController());
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +35,13 @@ class LayoutScreen extends StatelessWidget {
             titleSpacing: 0,
             title: const Text('Court Dairy'),
             actions: [
+              IconButton(
+                onPressed: () {
+                  Get.to(() => CaseSearchScreen(),
+                      transition: Transition.downToUp);
+                },
+                icon: const Icon(Icons.search),
+              ),
               IconButton(
                 onPressed: () {
                   Get.to(() => CalculatorScreen(), fullscreenDialog: true);
@@ -63,7 +74,8 @@ class LayoutScreen extends StatelessWidget {
                     if (!ActivationGuard.check()) return;
                     final index = DefaultTabController.of(context).index;
                     if (index == 0) {
-                      // add later
+                      Get.to(() => const AddCaseScreen(),
+                          fullscreenDialog: true);
                     } else if (index == 1) {
                       Get.to(() => const AddPartyScreen(),
                           fullscreenDialog: true);


### PR DESCRIPTION
## Summary
- add date-based filtering with counts and animated case list
- introduce case detail screen and search experience
- expose global add-case action and app-wide case search

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c036854083309b36bf4a4befdf64