### PR TITLE
Remove Taka sign from accounts card

### DIFF
--- a/lib/modules/layout/widgets/accounts_card.dart
+++ b/lib/modules/layout/widgets/accounts_card.dart
@@ -34,9 +34,9 @@ class AccountsCard extends StatelessWidget {
                   return Text(
                     NumberFormat.currency(
                       locale: 'bn_BD',
-                      symbol: '৳',
+                      symbol: '',
                       decimalDigits: 0,
-                    ).format(value), // Format the number as currency
+                    ).format(value).trim(), // Format the number as currency
                   );
                 },
               ),


### PR DESCRIPTION
## Summary
- remove Taka currency symbol from the accounts card widget so balances show as plain numbers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4368962248330a624b24bc203b4ce