### PR TITLE
feat: add border to layout tab bar

### DIFF
--- a/lib/modules/layout/screens/layout_screen.dart
+++ b/lib/modules/layout/screens/layout_screen.dart
@@ -104,8 +104,10 @@ class LayoutScreen extends StatelessWidget {
               Expanded(
                 child: Column(
                   children: [
-                    const TabBar(
-                      tabs: [
+                    TabBar(
+                      dividerColor:
+                          Theme.of(context).colorScheme.outline,
+                      tabs: const [
                         Tab(text: AppTexts.tabParty),
                         Tab(text: AppTexts.tabCase),
                         Tab(text: AppTexts.tabAccounts),


### PR DESCRIPTION
## Summary
- show app bar divider in layout's tab bar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b491f3ade08330b9b95c4dea4a09fe