### PR TITLE
Match chip borders to app bar color

### DIFF
--- a/lib/modules/accounts/screens/all_transactions_screen.dart
+++ b/lib/modules/accounts/screens/all_transactions_screen.dart
@@ -21,6 +21,8 @@ class AllTransactionsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final types = ['All', ...getTransactionTypes()];
     final dates = ['All', 'Today', 'This Week', 'This Month'];
+    final appBarColor = Theme.of(context).appBarTheme.backgroundColor ??
+        Theme.of(context).colorScheme.primary;
     return Scaffold(
       appBar: AppBar(title: const Text('All Transactions')),
       body: Column(
@@ -45,6 +47,13 @@ class AllTransactionsScreen extends StatelessWidget {
                             label: Text(t),
                             selected: selected,
                             onSelected: (_) => typeFilter.value = t,
+                            shape: StadiumBorder(
+                              side: BorderSide(
+                                color: selected
+                                    ? Colors.transparent
+                                    : appBarColor,
+                              ),
+                            ),
                           ),
                         );
                       }).toList(),

--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -20,6 +20,8 @@ class AddCaseScreen extends StatelessWidget {
       required List<String> options,
       required RxnString selected,
     }) {
+      final appBarColor = Theme.of(context).appBarTheme.backgroundColor ??
+          Theme.of(context).colorScheme.primary;
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -37,6 +39,13 @@ class AddCaseScreen extends StatelessWidget {
                       label: Text(t),
                       selected: isSelected,
                       onSelected: (_) => selected.value = t,
+                      shape: StadiumBorder(
+                        side: BorderSide(
+                          color: isSelected
+                              ? Colors.transparent
+                              : appBarColor,
+                        ),
+                      ),
                     ),
                   );
                 }).toList(),

--- a/lib/modules/case/screens/all_case_screen.dart
+++ b/lib/modules/case/screens/all_case_screen.dart
@@ -14,6 +14,8 @@ class AllCaseScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final appBarColor = Theme.of(context).appBarTheme.backgroundColor ??
+        Theme.of(context).colorScheme.primary;
     return Scaffold(
       appBar: AppBar(title: const Text('All Cases')),
       body: Column(
@@ -46,7 +48,13 @@ class AllCaseScreen extends StatelessWidget {
                             selected: selected,
                             onSelected: (_) => typeFilter.value = t,
                             shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(20)),
+                              borderRadius: BorderRadius.circular(20),
+                              side: BorderSide(
+                                color: selected
+                                    ? Colors.transparent
+                                    : appBarColor,
+                              ),
+                            ),
                             materialTapTargetSize:
                                 MaterialTapTargetSize.shrinkWrap,
                             visualDensity: VisualDensity.compact,
@@ -74,7 +82,13 @@ class AllCaseScreen extends StatelessWidget {
                             selected: selected,
                             onSelected: (_) => courtFilter.value = t,
                             shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(20)),
+                              borderRadius: BorderRadius.circular(20),
+                              side: BorderSide(
+                                color: selected
+                                    ? Colors.transparent
+                                    : appBarColor,
+                              ),
+                            ),
                             materialTapTargetSize:
                                 MaterialTapTargetSize.shrinkWrap,
                             visualDensity: VisualDensity.compact,

--- a/lib/modules/case/screens/case_detail_screen.dart
+++ b/lib/modules/case/screens/case_detail_screen.dart
@@ -29,6 +29,7 @@ class CaseDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = Get.find<CaseController>();
     final theme = Theme.of(context);
+    final appBarColor = theme.appBarTheme.backgroundColor ?? theme.colorScheme.primary;
     final statuses = const ['Ongoing', 'Disposed', 'Completed'];
 
     Widget chip(String text, {Color? color, IconData? icon}) {
@@ -291,6 +292,9 @@ class CaseDetailScreen extends StatelessWidget {
                               children: current.hearingDates.map((ts) {
                                 return InputChip(
                                   label: Text(_fmtDate(ts)),
+                                  shape: StadiumBorder(
+                                    side: BorderSide(color: appBarColor),
+                                  ),
                                   onDeleted: () async {
                                     PanaraConfirmDialog.show(
                                       context,

--- a/lib/modules/case/screens/case_screen.dart
+++ b/lib/modules/case/screens/case_screen.dart
@@ -44,14 +44,14 @@ class CaseScreen extends StatelessWidget {
             scrollDirection: Axis.horizontal,
             child: Row(
               children: [
-                filterChip(
-                    'today', "Today's (${controller.todayCount})", controller),
-                filterChip('tomorrow', 'Tomorrow (${controller.tomorrowCount})',
-                    controller),
-                filterChip(
-                    'week', 'This Week (${controller.weekCount})', controller),
-                filterChip('month', 'This Month (${controller.monthCount})',
-                    controller),
+                filterChip(context, 'today',
+                    "Today's (${controller.todayCount})", controller),
+                filterChip(context, 'tomorrow',
+                    'Tomorrow (${controller.tomorrowCount})', controller),
+                filterChip(context, 'week',
+                    'This Week (${controller.weekCount})', controller),
+                filterChip(context, 'month',
+                    'This Month (${controller.monthCount})', controller),
               ],
             ),
           ),
@@ -87,14 +87,23 @@ class CaseScreen extends StatelessWidget {
   }
 }
 
-Widget filterChip(String key, String label, CaseController controller) {
+Widget filterChip(
+    BuildContext context, String key, String label, CaseController controller) {
+  final appBarColor =
+      Theme.of(context).appBarTheme.backgroundColor ?? Theme.of(context).colorScheme.primary;
+  final selected = controller.selectedFilter.value == key;
   return Padding(
     padding: const EdgeInsets.symmetric(horizontal: 4),
     child: ChoiceChip(
       label: Text(label, style: const TextStyle(fontSize: 12)),
-      selected: controller.selectedFilter.value == key,
+      selected: selected,
       onSelected: (_) => controller.selectedFilter.value = key,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(
+          color: selected ? Colors.transparent : appBarColor,
+        ),
+      ),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       visualDensity: VisualDensity.compact,
       labelPadding: const EdgeInsets.symmetric(horizontal: 8),

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -17,14 +17,25 @@ class EditCaseScreen extends StatelessWidget {
     final controller = Get.put(EditCaseController(caseItem));
 
     Widget caseTypeChips() {
+      final appBarColor = Theme.of(context).appBarTheme.backgroundColor ??
+          Theme.of(context).colorScheme.primary;
       return Wrap(
         spacing: 8,
         children: controller.caseTypes.map((type) {
-          return Obx(() => ChoiceChip(
-                label: Text(type),
-                selected: controller.selectedCaseType.value == type,
-                onSelected: (_) => controller.selectedCaseType.value = type,
-              ));
+          return Obx(() {
+            final isSelected = controller.selectedCaseType.value == type;
+            return ChoiceChip(
+              label: Text(type),
+              selected: isSelected,
+              onSelected: (_) => controller.selectedCaseType.value = type,
+              shape: StadiumBorder(
+                side: BorderSide(
+                  color:
+                      isSelected ? Colors.transparent : appBarColor,
+                ),
+              ),
+            );
+          });
         }).toList(),
       );
     }

--- a/lib/modules/court_dairy/screens/buy_sms_screen.dart
+++ b/lib/modules/court_dairy/screens/buy_sms_screen.dart
@@ -17,6 +17,7 @@ class BuySmsView extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
+    final appBarColor = theme.appBarTheme.backgroundColor ?? cs.primary;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
@@ -154,6 +155,13 @@ class BuySmsView extends StatelessWidget {
                                         selected: selected,
                                         onSelected: (_) =>
                                             controller.smsCount.value = v,
+                                        shape: StadiumBorder(
+                                          side: BorderSide(
+                                            color: selected
+                                                ? Colors.transparent
+                                                : appBarColor,
+                                          ),
+                                        ),
                                       );
                                     }))
                                 .toList(),


### PR DESCRIPTION
## Summary
- Use app bar background color for unselected chip borders across the app
- Update chip helpers to apply dynamic border colors

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49c21fff48330919b2f3454213ea8