### PR TITLE
Add daily hearing-date reminders and overdue case page

### DIFF
--- a/lib/modules/case/screens/overdue_cases_screen.dart
+++ b/lib/modules/case/screens/overdue_cases_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/case_controller.dart';
+import '../widgets/case_update_tile.dart';
+
+class OverdueCasesScreen extends StatelessWidget {
+  const OverdueCasesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(CaseController());
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pending Hearing Updates'),
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final list = controller.overdueCases;
+        if (list.isEmpty) {
+          return const Center(child: Text('No pending cases'));
+        }
+        return ListView.builder(
+          itemCount: list.length,
+          itemBuilder: (context, index) => CaseUpdateTile(caseItem: list[index]),
+        );
+      }),
+    );
+  }
+}
+

--- a/lib/modules/case/services/case_service.dart
+++ b/lib/modules/case/services/case_service.dart
@@ -106,4 +106,25 @@ class CaseService {
         .doc(docId)
         .update({'caseStatus': status});
   }
+
+  static Future<void> updateNextHearingDate(
+      String docId, String userId, Timestamp newDate) async {
+    final docRef = _firestore
+        .collection(AppCollections.lawyers)
+        .doc(userId)
+        .collection(AppCollections.cases)
+        .doc(docId);
+
+    await _firestore.runTransaction((tx) async {
+      final snap = await tx.get(docRef);
+      final data = snap.data() as Map<String, dynamic>?;
+      final dates = List<Timestamp>.from(data?['hearingDates'] ?? []);
+      if (dates.isNotEmpty) {
+        dates[0] = newDate;
+      } else {
+        dates.add(newDate);
+      }
+      tx.update(docRef, {'hearingDates': dates});
+    });
+  }
 }

--- a/lib/modules/case/widgets/case_update_tile.dart
+++ b/lib/modules/case/widgets/case_update_tile.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+import '../../../models/court_case.dart';
+import '../controllers/case_controller.dart';
+
+class CaseUpdateTile extends StatelessWidget {
+  const CaseUpdateTile({super.key, required this.caseItem});
+
+  final CourtCase caseItem;
+
+  String _format(DateTime date) => DateFormat('dd MMM yyyy').format(date);
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CaseController>();
+    final lastDate =
+        caseItem.hearingDates.isNotEmpty ? caseItem.hearingDates.first.toDate() : null;
+    return Card(
+      child: ListTile(
+        title: Text(caseItem.caseTitle),
+        subtitle: Text(
+          'Case No: ${caseItem.caseNumber}\nLast date: ${lastDate != null ? _format(lastDate) : 'N/A'}',
+        ),
+        isThreeLine: true,
+        trailing: IconButton(
+          icon: const Icon(Icons.edit_calendar_outlined),
+          onPressed: () async {
+            final picked = await showDatePicker(
+              context: context,
+              initialDate: DateTime.now(),
+              firstDate: DateTime(2000),
+              lastDate: DateTime(2100),
+            );
+            if (picked != null) {
+              await controller.updateNextHearingDate(caseItem, picked);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -2,7 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:courtdiary/services/app_update_service.dart';
 import 'package:courtdiary/services/fcm_service.dart';
 import 'package:courtdiary/services/local_storage.dart';
+import 'package:courtdiary/services/local_notification.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:get/get.dart';
+import '../modules/case/screens/overdue_cases_screen.dart';
 import '../utils/app_config.dart';
 
 class AppInitializer {
@@ -26,7 +29,21 @@ class AppInitializer {
     // 5) FCM token initialization and refresh listener
     await FcmService().initialize();
 
-    // 6) Check for app updates in background
+    // 6) Daily reminder to update hearing dates
+    final localNoti = LocalNotificationService();
+    await localNoti.initialize(onTap: (payload) {
+      if (payload == 'overdue_cases') {
+        Get.to(() => const OverdueCasesScreen());
+      }
+    });
+    await localNoti.scheduleDailyNotification(
+      id: 1,
+      title: 'Update hearing dates',
+      body: 'Tap to update past hearing dates',
+      payload: 'overdue_cases',
+    );
+
+    // 7) Check for app updates in background
     await AppUpdateService.checkForAppUpdate();
   }
 }

--- a/lib/services/local_notification.dart
+++ b/lib/services/local_notification.dart
@@ -5,7 +5,7 @@ class LocalNotificationService {
   bool isInit = false;
   bool get isInited => isInit;
 
-  Future<void> initialize() async {
+  Future<void> initialize({Function(String?)? onTap}) async {
     if (isInit) return;
     const androidInitializationSettings =
         AndroidInitializationSettings('@mipmap/ic_launcher');
@@ -13,7 +13,10 @@ class LocalNotificationService {
 
     const initSetting = InitializationSettings(
         android: androidInitializationSettings, iOS: iosInitializationSettings);
-    await notificationsPlugin.initialize(initSetting);
+    await notificationsPlugin.initialize(initSetting,
+        onDidReceiveNotificationResponse: (details) {
+      onTap?.call(details.payload);
+    });
     isInit = true;
   }
 
@@ -33,5 +36,17 @@ class LocalNotificationService {
     int timestamp = DateTime.now().millisecondsSinceEpoch;
     int id = timestamp % 2147483647;
     notificationsPlugin.show(id, title, body, notificationDetails());
+  }
+
+  Future<void> scheduleDailyNotification({
+    required int id,
+    required String title,
+    required String body,
+    String? payload,
+  }) async {
+    await notificationsPlugin.cancel(id);
+    notificationsPlugin.periodicallyShow(id, title, body, RepeatInterval.daily,
+        notificationDetails(),
+        androidAllowWhileIdle: true, payload: payload);
   }
 }


### PR DESCRIPTION
## Summary
- schedule daily local notifications that open overdue case updater
- support replacing next hearing date in case service and controller
- add screen and tile to list cases with past hearing dates for quick updates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ddec32bc8330ad8d732e0f0c9552