### PR TITLE
feat: add calendar view for cases

### DIFF
--- a/lib/modules/case/controllers/case_controller.dart
+++ b/lib/modules/case/controllers/case_controller.dart
@@ -56,6 +56,19 @@ class CaseController extends GetxController {
     }).toList();
   }
 
+  Map<int, int> get monthCaseCounts {
+    final now = DateTime.now();
+    final map = <int, int>{};
+    for (final c in cases) {
+      final d = _nextDate(c);
+      if (d == null) continue;
+      if (d.year == now.year && d.month == now.month) {
+        map[d.day] = (map[d.day] ?? 0) + 1;
+      }
+    }
+    return map;
+  }
+
   List<CourtCase> get overdueCases {
     final now = DateTime.now();
     return cases.where((c) {

--- a/lib/modules/case/screens/case_calendar_screen.dart
+++ b/lib/modules/case/screens/case_calendar_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../controllers/case_controller.dart';
+
+class CaseCalendarScreen extends StatelessWidget {
+  CaseCalendarScreen({super.key});
+
+  final _caseController = Get.find<CaseController>();
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final daysInMonth = DateUtils.getDaysInMonth(now.year, now.month);
+    final firstWeekday = DateTime(now.year, now.month, 1).weekday; // 1 = Monday
+
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        title: const Text('Cases Calendar'),
+        actions: [
+          IconButton(
+            onPressed: () => Get.back(),
+            icon: const Icon(HugeIcons.strokeRoundedArrowShrink),
+          ),
+        ],
+      ),
+      body: Obx(() {
+        final counts = _caseController.monthCaseCounts;
+        final totalCells = daysInMonth + firstWeekday - 1;
+        return GridView.builder(
+          padding: const EdgeInsets.all(16),
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 7,
+            crossAxisSpacing: 4,
+            mainAxisSpacing: 4,
+            childAspectRatio: 1,
+          ),
+          itemCount: totalCells,
+          itemBuilder: (context, index) {
+            if (index < firstWeekday - 1) {
+              return const SizedBox.shrink();
+            }
+            final day = index - (firstWeekday - 1) + 1;
+            final count = counts[day] ?? 0;
+            return Container(
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    day.toString(),
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '$count case${count == 1 ? '' : 's'}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/layout/screens/layout_screen.dart
+++ b/lib/modules/layout/screens/layout_screen.dart
@@ -12,6 +12,7 @@ import '../../../screens/customer_service_screen.dart';
 import '../../../constants/app_texts.dart';
 import '../../accounts/screens/add_transaction_screen.dart';
 import '../../case/screens/case_fullscreen_screen.dart';
+import '../../case/screens/case_calendar_screen.dart';
 import '../../party/screens/add_party_screen.dart';
 import '../../party/screens/party_screen.dart';
 import '../widgets/app_drawer.dart';
@@ -49,6 +50,13 @@ class LayoutScreen extends StatelessWidget {
                 },
                 icon: const Icon(HugeIcons.strokeRoundedArrowAllDirection),
                 tooltip: 'Cases Fullscreen',
+              ),
+              IconButton(
+                onPressed: () {
+                  Get.to(() => CaseCalendarScreen(), fullscreenDialog: true);
+                },
+                icon: const Icon(HugeIcons.strokeRoundedCalendar01),
+                tooltip: 'Cases Calendar',
               ),
               IconButton(
                 onPressed: () {


### PR DESCRIPTION
## Summary
- add calendar screen showing current month with case counts
- expose monthly case counts in controller
- open calendar from layout app bar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e1b864688330900426d0203f1549