### PR TITLE
feat: schedule daily notification for tomorrow's cases

### DIFF
--- a/lib/modules/case/screens/tomorrow_cases_screen.dart
+++ b/lib/modules/case/screens/tomorrow_cases_screen.dart
@@ -1,0 +1,29 @@
+import 'package:courtdiary/widgets/data_not_found.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/case_controller.dart';
+import '../widgets/case_tile.dart';
+
+class TomorrowCasesScreen extends StatelessWidget {
+  const TomorrowCasesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CaseController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text("Tomorrow's Cases")),
+      body: Obx(() {
+        final list = controller.tomorrowCases;
+        if (list.isEmpty) {
+          return const DataNotFound(
+              title: 'Sorry', subtitle: 'No cases found');
+        }
+        return ListView.builder(
+          itemCount: list.length,
+          itemBuilder: (_, i) => CaseTile(caseItem: list[i]),
+        );
+      }),
+    );
+  }
+}

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -6,6 +6,7 @@ import 'package:courtdiary/services/local_notification.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:get/get.dart';
 import '../modules/case/screens/overdue_cases_screen.dart';
+import '../modules/case/screens/tomorrow_cases_screen.dart';
 import '../utils/app_config.dart';
 
 class AppInitializer {
@@ -34,6 +35,8 @@ class AppInitializer {
     await localNoti.initialize(onTap: (payload) {
       if (payload == 'overdue_cases') {
         Get.to(() => const OverdueCasesScreen());
+      } else if (payload == 'tomorrow_cases') {
+        Get.to(() => const TomorrowCasesScreen());
       }
     });
     await localNoti.scheduleDailyNotification(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   date_picker_plus: ^4.1.0
   flutter_local_notifications: ^18.0.1
   permission_handler: ^11.3.1
+  timezone: ^0.9.2
   onesignal_flutter: ^5.2.9
   url_launcher: ^6.3.1
   uuid: ^4.5.1


### PR DESCRIPTION
## Summary
- show local notifications at 4pm listing tomorrow's cases
- open new screen with tomorrow's case list when notification is tapped
- add timezone dependency and utility for scheduling at specific time

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e436364c83309201cbde46302d41