### PR TITLE
feat: add typeahead fields for court and judge

### DIFF
--- a/lib/models/lawyer.dart
+++ b/lib/models/lawyer.dart
@@ -11,6 +11,7 @@ class Lawyer {
   final int subFor;
   final DateTime subStartsAt;
   final List<String> courts; // ✅ New field
+  final List<String> judges;
 
   Lawyer({
     this.docId,
@@ -22,7 +23,8 @@ class Lawyer {
     required this.isActive,
     required this.subFor,
     required this.subStartsAt,
-    this.courts = const [], 
+    this.courts = const [],
+    this.judges = const [],
   });
 
   /// Convert to Firestore Map
@@ -37,6 +39,7 @@ class Lawyer {
       'subFor': subFor,
       'subStartsAt': subStartsAt,
       'courts': courts, // ✅ Save courts list
+      'judges': judges,
     };
   }
 
@@ -53,6 +56,7 @@ class Lawyer {
       subFor: map['subFor'] ?? 0,
       subStartsAt: (map['subStartsAt'] as Timestamp).toDate(),
       courts: List<String>.from(map['courts'] ?? []), // ✅ Load courts safely
+      judges: List<String>.from(map['judges'] ?? []),
     );
   }
 

--- a/lib/modules/auth/services/auth_service.dart
+++ b/lib/modules/auth/services/auth_service.dart
@@ -34,7 +34,8 @@ class AuthService {
             subFor: 0,
             subStartsAt: DateTime.now(),
             isActive: true,
-            courts: []);
+            courts: [],
+            judges: []);
 
         await _firestore
             .collection(AppCollections.lawyers)

--- a/lib/modules/case/controllers/add_case_controller.dart
+++ b/lib/modules/case/controllers/add_case_controller.dart
@@ -10,6 +10,7 @@ import '../../../models/party.dart';
 import '../../../services/app_firebase.dart';
 import '../../party/services/party_service.dart';
 import '../services/case_service.dart';
+import '../../../constants/app_collections.dart';
 
 class AddCaseController extends GetxController {
   final caseTitle = TextEditingController();
@@ -35,6 +36,9 @@ class AddCaseController extends GetxController {
 
   final documents = <String>[].obs;
 
+  final allCourtNames = <String>[].obs;
+  final allJudgeNames = <String>[].obs;
+
   final RxBool isLoading = false.obs;
 
   @override
@@ -45,6 +49,40 @@ class AddCaseController extends GetxController {
       PartyService.getParties(user.uid).listen((list) {
         parties.value = list;
       });
+      _loadSuggestions(user.uid);
+    }
+  }
+
+  Future<void> _loadSuggestions(String uid) async {
+    final doc = await AppFirebase()
+        .firestore
+        .collection(AppCollections.lawyers)
+        .doc(uid)
+        .get();
+    final data = doc.data();
+    if (data != null) {
+      allCourtNames.assignAll(List<String>.from(data['courts'] ?? []));
+      allJudgeNames.assignAll(List<String>.from(data['judges'] ?? []));
+    }
+  }
+
+  Future<void> _updateSuggestions(
+      String uid, String court, String judge) async {
+    final updates = <String, dynamic>{};
+    if (court.isNotEmpty && !allCourtNames.contains(court)) {
+      allCourtNames.add(court);
+      updates['courts'] = FieldValue.arrayUnion([court]);
+    }
+    if (judge.isNotEmpty && !allJudgeNames.contains(judge)) {
+      allJudgeNames.add(judge);
+      updates['judges'] = FieldValue.arrayUnion([judge]);
+    }
+    if (updates.isNotEmpty) {
+      await AppFirebase()
+          .firestore
+          .collection(AppCollections.lawyers)
+          .doc(uid)
+          .update(updates);
     }
   }
 
@@ -90,6 +128,8 @@ class AddCaseController extends GetxController {
       );
 
       await CaseService.addCase(caseModel, user.uid);
+      await _updateSuggestions(
+          user.uid, caseModel.courtName, caseModel.judgeName);
       return true;
     } catch (e) {
       return false;

--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -2,6 +2,7 @@ import 'package:hugeicons/hugeicons.dart';
 
 import '../../../widgets/dynamic_multi_step_form.dart';
 import '../../../widgets/app_text_from_field.dart';
+import '../../../widgets/app_type_ahead_field.dart';
 import '../../../constants/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -169,11 +170,12 @@ class AddCaseScreen extends StatelessWidget {
                       hintText: 'Enter case title',
                       prefixIcon: Icons.title,
                     ),
-                    AppTextFromField(
+                    AppTypeAheadField(
                       controller: controller.courtName,
                       label: 'Court Name',
                       hintText: 'Enter court name',
                       prefixIcon: Icons.account_balance,
+                      suggestions: controller.allCourtNames,
                     ),
                     AppTextFromField(
                       controller: controller.caseNumber,
@@ -258,11 +260,12 @@ class AddCaseScreen extends StatelessWidget {
                               controller.hearingDate.value = picked;
                           },
                         )),
-                    AppTextFromField(
+                    AppTypeAheadField(
                       controller: controller.judgeName,
                       label: 'Judge Name',
                       hintText: 'Enter judge name',
                       prefixIcon: Icons.gavel,
+                      suggestions: controller.allJudgeNames,
                     ),
                     AppTextFromField(
                       controller: controller.courtOrder,

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -1,4 +1,5 @@
 import '../../../widgets/dynamic_multi_step_form.dart';
+import '../../../widgets/app_type_ahead_field.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:panara_dialogs/panara_dialogs.dart';
@@ -67,9 +68,12 @@ class EditCaseScreen extends StatelessWidget {
                   controller: controller.caseTitle,
                   decoration: const InputDecoration(labelText: 'Case Title'),
                 ),
-                TextField(
+                AppTypeAheadField(
                   controller: controller.courtName,
-                  decoration: const InputDecoration(labelText: 'Court Name'),
+                  label: 'Court Name',
+                  hintText: 'Enter court name',
+                  prefixIcon: Icons.account_balance,
+                  suggestions: controller.allCourtNames,
                 ),
                 TextField(
                   controller: controller.caseNumber,
@@ -137,9 +141,12 @@ class EditCaseScreen extends StatelessWidget {
                         if (picked != null) controller.hearingDate.value = picked;
                       },
                     )),
-                TextField(
+                AppTypeAheadField(
                   controller: controller.judgeName,
-                  decoration: const InputDecoration(labelText: 'Judge Name'),
+                  label: 'Judge Name',
+                  hintText: 'Enter judge name',
+                  prefixIcon: Icons.gavel,
+                  suggestions: controller.allJudgeNames,
                 ),
                 TextField(
                   controller: controller.courtOrder,

--- a/lib/widgets/app_type_ahead_field.dart
+++ b/lib/widgets/app_type_ahead_field.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+
+import '../local_library/text_from_field_wraper.dart';
+
+class AppTypeAheadField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final String hintText;
+  final IconData prefixIcon;
+  final List<String> suggestions;
+  final TextFormFieldPosition textFormFieldPosition;
+  final FormFieldValidator<String>? validator;
+  final ValueChanged<String>? onChanged;
+  final GestureTapCallback? onTap;
+  final ValueChanged<String>? onFieldSubmitted;
+
+  const AppTypeAheadField({
+    super.key,
+    required this.controller,
+    required this.label,
+    required this.hintText,
+    required this.prefixIcon,
+    required this.suggestions,
+    this.textFormFieldPosition = TextFormFieldPosition.alone,
+    this.validator,
+    this.onChanged,
+    this.onTap,
+    this.onFieldSubmitted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return TextFormFieldWrapper(
+      borderFocusedColor: cs.primary,
+      position: textFormFieldPosition,
+      formField: TypeAheadFormField<String>(
+        textFieldConfiguration: TextFieldConfiguration(
+          controller: controller,
+          cursorColor: Theme.of(context).colorScheme.onSurface,
+          decoration: InputDecoration(
+            border: InputBorder.none,
+            hintText: hintText,
+            labelText: label,
+            prefixIcon: Icon(prefixIcon, color: cs.onSurfaceVariant),
+          ),
+          onChanged: onChanged,
+          onTap: onTap,
+          onSubmitted: onFieldSubmitted,
+        ),
+        suggestionsCallback: (pattern) {
+          return suggestions.where((s) =>
+              s.toLowerCase().contains(pattern.toLowerCase()));
+        },
+        itemBuilder: (context, suggestion) {
+          return ListTile(
+            title: Text(suggestion),
+          );
+        },
+        onSuggestionSelected: (suggestion) {
+          controller.text = suggestion;
+        },
+        validator: validator,
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   lottie: ^3.3.1
   dio: ^5.9.0
   image_picker: ^1.1.5
+  flutter_typeahead: ^4.9.0
   animations: ^2.0.11
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- suggest previously used courts and judges via typeahead fields
- persist unique court and judge names in lawyer profile
- add flutter_typeahead dependency

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc03efe08330838b3b3eeed1984f