### PR TITLE
Remove time restriction for overdue cases bottom sheet

### DIFF
--- a/lib/modules/layout/screens/layout_screen.dart
+++ b/lib/modules/layout/screens/layout_screen.dart
@@ -66,15 +66,8 @@ class _LayoutScreenState extends State<LayoutScreen>
     }
   }
 
-  bool _isEveningToMorningWindow(DateTime now) {
-    // Show between 16:00 (4 PM) and 08:59 next day
-    return now.hour >= 16 || now.hour < 9;
-  }
-
   Future<void> _maybeShowOverdueSheet() async {
     if (!mounted || _isShowingOverdueSheet) return;
-    final now = DateTime.now();
-    if (!_isEveningToMorningWindow(now)) return;
 
     // If still loading, skip this attempt.
     if (_caseController.isLoading.value) return;


### PR DESCRIPTION
## Summary
- Show overdue cases bottom sheet whenever app opens, without time window

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c976242883308a73d92be4d42986