### PR TITLE
Ensure status chips contrast with background on case details

### DIFF
--- a/lib/modules/case/screens/case_detail_screen.dart
+++ b/lib/modules/case/screens/case_detail_screen.dart
@@ -64,16 +64,28 @@ class CaseDetailScreen extends StatelessWidget {
       );
     }
 
-    Color _statusColor(String status) {
+    Color _statusBgColor(String status) {
       switch (status.toLowerCase()) {
         case 'ongoing':
-          return theme.colorScheme.primary;
+          return Colors.white;
         case 'disposed':
-          return Colors.orange;
+          return Colors.red;
         case 'completed':
           return Colors.green;
         default:
           return theme.colorScheme.secondary;
+      }
+    }
+
+    Color _statusTextColor(String status) {
+      switch (status.toLowerCase()) {
+        case 'ongoing':
+          return Colors.black;
+        case 'disposed':
+        case 'completed':
+          return Colors.white;
+        default:
+          return theme.colorScheme.onSecondary;
       }
     }
 
@@ -170,8 +182,7 @@ class CaseDetailScreen extends StatelessWidget {
                                 style: TextStyle(fontSize: 14)),
                             Container(
                               decoration: BoxDecoration(
-                                color: _statusColor(caseItem.caseStatus)
-                                    .withOpacity(0.12),
+                                color: _statusBgColor(caseItem.caseStatus),
                                 borderRadius: BorderRadius.circular(20),
                               ),
                               padding: const EdgeInsets.symmetric(
@@ -181,7 +192,8 @@ class CaseDetailScreen extends StatelessWidget {
                                 style: TextStyle(
                                   fontWeight: FontWeight.w700,
                                   fontSize: 14,
-                                  color: _statusColor(caseItem.caseStatus),
+                                  color:
+                                      _statusTextColor(caseItem.caseStatus),
                                 ),
                               ),
                             ),


### PR DESCRIPTION
## Summary
- Add helpers to compute background and text colors for case status labels
- Use white, red, and green backgrounds with contrasting text to keep status visible

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d65ff92483309c80988f12d7a040