### PR TITLE
chore: remove document input from case editing

### DIFF
--- a/lib/modules/case/controllers/edit_case_controller.dart
+++ b/lib/modules/case/controllers/edit_case_controller.dart
@@ -21,7 +21,6 @@ class EditCaseController extends GetxController {
   late final TextEditingController caseSummary;
   late final TextEditingController judgeName;
   late final TextEditingController courtOrder;
-  late final TextEditingController document;
 
   final RxnString selectedCaseType = RxnString();
   final Rx<DateTime?> filedDate = Rx<DateTime?>(null);
@@ -49,10 +48,6 @@ class EditCaseController extends GetxController {
     judgeName = TextEditingController(text: caseModel.judgeName);
     courtOrder = TextEditingController(
         text: caseModel.courtOrders.isNotEmpty ? caseModel.courtOrders.first : '');
-    document = TextEditingController(
-        text: caseModel.documentsAttached.isNotEmpty
-            ? caseModel.documentsAttached.first
-            : '');
     selectedCaseType.value = caseModel.caseType;
     filedDate.value = caseModel.filedDate.toDate();
     if (caseModel.hearingDates.isNotEmpty) {
@@ -121,8 +116,6 @@ class EditCaseController extends GetxController {
             ? [Timestamp.fromDate(hearingDate.value!)]
             : <Timestamp>[]
         ..judgeName = judgeName.text.trim()
-        ..documentsAttached =
-            document.text.isNotEmpty ? [document.text.trim()] : <String>[]
         ..courtOrders =
             courtOrder.text.isNotEmpty ? [courtOrder.text.trim()] : <String>[]
         ..caseSummary = caseSummary.text.trim();

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -152,10 +152,6 @@ class EditCaseScreen extends StatelessWidget {
                   controller: controller.courtOrder,
                   decoration: const InputDecoration(labelText: 'Court Order'),
                 ),
-                TextField(
-                  controller: controller.document,
-                  decoration: const InputDecoration(labelText: 'Document'),
-                ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- remove document text field from edit case screen
- drop document controller and documentsAttached update in edit case controller

## Testing
- `flutter format lib/modules/case/screens/edit_case_screen.dart lib/modules/case/controllers/edit_case_controller.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6d7e0ce3c8330b50a5612c2acd64f