### PR TITLE
Add SMS notification toggle for parties

### DIFF
--- a/lib/models/party.dart
+++ b/lib/models/party.dart
@@ -5,6 +5,7 @@ class Party {
   final String address;
   final String lawyerId;
   final String? photoUrl;
+  final bool isSendSms;
 
   // Constructor
   Party({
@@ -14,6 +15,7 @@ class Party {
     required this.address,
     required this.lawyerId, // Include the new field in the constructor
     this.photoUrl,
+    this.isSendSms = true,
   });
 
   // Method to convert Party object to a Map (for example, to store in a database)
@@ -24,6 +26,7 @@ class Party {
       'address': address,
       'lawyerId': lawyerId, // Include the new field in the map
       'photoUrl': photoUrl,
+      'isSendSms': isSendSms,
     // Include dynamic fields in the map
     };
   }
@@ -37,6 +40,7 @@ class Party {
       address: map['address'],
       lawyerId: map['lawyerId'], // Extract the new field from the map
       photoUrl: map['photoUrl'],
+      isSendSms: map['isSendSms'] ?? true,
     );
 
     return party;

--- a/lib/modules/party/controllers/add_party_controller.dart
+++ b/lib/modules/party/controllers/add_party_controller.dart
@@ -19,6 +19,7 @@ class AddPartyController extends GetxController {
 
   final RxBool isLoading = false.obs;
   final RxBool enableBtn = false.obs;
+  final RxBool isSendSms = true.obs;
 
   @override
   void onInit() {
@@ -146,6 +147,7 @@ class AddPartyController extends GetxController {
         address: address.text.trim(),
         lawyerId: user.uid,
         photoUrl: photoUrl,
+        isSendSms: isSendSms.value,
       );
 
       await PartyService.addParty(party);

--- a/lib/modules/party/controllers/edit_party_controller.dart
+++ b/lib/modules/party/controllers/edit_party_controller.dart
@@ -22,6 +22,7 @@ class EditPartyController extends GetxController {
 
   final RxBool isLoading = false.obs;
   final RxBool enableBtn = false.obs;
+  final RxBool isSendSms = true.obs;
 
   @override
   void onInit() {
@@ -29,6 +30,7 @@ class EditPartyController extends GetxController {
     name.text = party.name;
     phone.text = party.phone;
     address.text = party.address;
+    isSendSms.value = party.isSendSms;
 
     name.addListener(_validate);
     phone.addListener(_validate);
@@ -151,6 +153,7 @@ class EditPartyController extends GetxController {
         address: address.text.trim(),
         lawyerId: user.uid,
         photoUrl: photoUrl,
+        isSendSms: isSendSms.value,
       );
 
       await PartyService.updateParty(updated);

--- a/lib/modules/party/controllers/party_profile_controller.dart
+++ b/lib/modules/party/controllers/party_profile_controller.dart
@@ -10,6 +10,14 @@ class PartyProfileController extends GetxController {
   PartyProfileController(this.party);
 
   final RxBool isDeleting = false.obs;
+  final RxBool isSendSms = false.obs;
+  final RxBool isUpdatingSms = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    isSendSms.value = party.isSendSms;
+  }
 
   Future<void> deleteParty() async {
     if (isDeleting.value) return;
@@ -33,6 +41,34 @@ class PartyProfileController extends GetxController {
       );
     } finally {
       isDeleting.value = false;
+    }
+  }
+
+  Future<void> updateSms(bool value) async {
+    if (party.docId == null || isUpdatingSms.value) return;
+    if (!ActivationGuard.check()) return;
+    try {
+      isUpdatingSms.value = true;
+      final updated = Party(
+        docId: party.docId,
+        name: party.name,
+        phone: party.phone,
+        address: party.address,
+        lawyerId: party.lawyerId,
+        photoUrl: party.photoUrl,
+        isSendSms: value,
+      );
+      await PartyService.updateParty(updated);
+      isSendSms.value = value;
+    } catch (e) {
+      Get.snackbar(
+        'ত্রুটি',
+        'আপডেট ব্যর্থ হয়েছে',
+        backgroundColor: Colors.white,
+        colorText: Colors.red,
+      );
+    } finally {
+      isUpdatingSms.value = false;
     }
   }
 }

--- a/lib/modules/party/screens/add_party_screen.dart
+++ b/lib/modules/party/screens/add_party_screen.dart
@@ -62,6 +62,12 @@ class AddPartyScreen extends StatelessWidget {
               prefixIcon: Icons.home,
               isMaxLines: 3,
             ),
+            Obx(() => SwitchListTile(
+                  title: const Text('এসএমএস নোটিফায়ার'),
+                  contentPadding: EdgeInsets.zero,
+                  value: controller.isSendSms.value,
+                  onChanged: (v) => controller.isSendSms.value = v,
+                )),
             const SizedBox(height: 20),
           ],
         ),

--- a/lib/modules/party/screens/edit_party_screen.dart
+++ b/lib/modules/party/screens/edit_party_screen.dart
@@ -65,6 +65,12 @@ class EditPartyScreen extends StatelessWidget {
               prefixIcon: Icons.home,
               isMaxLines: 3,
             ),
+            Obx(() => SwitchListTile(
+                  title: const Text('এসএমএস নোটিফায়ার'),
+                  contentPadding: EdgeInsets.zero,
+                  value: controller.isSendSms.value,
+                  onChanged: (v) => controller.isSendSms.value = v,
+                )),
             const SizedBox(height: 20),
           ],
         ),

--- a/lib/modules/party/screens/party_profile_screen.dart
+++ b/lib/modules/party/screens/party_profile_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../models/party.dart';
-import '../../../widgets/app_button.dart';
 import '../../../widgets/app_info_row.dart';
 import '../controllers/party_profile_controller.dart';
 import 'edit_party_screen.dart';
@@ -18,6 +17,25 @@ class PartyProfileScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('পক্ষ প্রোফাইল'),
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              if (value == 'edit') {
+                if (ActivationGuard.check()) {
+                  Get.to(() => EditPartyScreen(party: party));
+                }
+              } else if (value == 'delete') {
+                if (ActivationGuard.check()) {
+                  controller.deleteParty();
+                }
+              }
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: 'edit', child: Text('এডিট')),
+              PopupMenuItem(value: 'delete', child: Text('ডিলিট')),
+            ],
+          ),
+        ],
       ),
       body: Obx(() {
         final theme = Theme.of(context);
@@ -126,39 +144,21 @@ class PartyProfileScreen extends StatelessWidget {
                   ),
 
                   const SizedBox(height: 16),
-
-                  // Actions
-                  Row(
-                    children: [
-                      Expanded(
-                        child: AppButton(
-                          label: 'এডিট',
-                          onPressed: () {
-                            if (ActivationGuard.check()) {
-                              Get.to(() => EditPartyScreen(party: party));
-                            }
-                          },
-                        ),
-                      ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: AppButton(
-                          label: 'ডিলিট',
-                          onPressed: controller.isDeleting.value
-                              ? null
-                              : () {
-                                  if (ActivationGuard.check()) {
-                                    controller.deleteParty();
-                                  }
-                                },
-                        ),
-                      ),
-                    ],
+                  Card(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    elevation: 0.5,
+                    child: Obx(() => SwitchListTile(
+                          title: const Text('এসএমএস নোটিফায়ার'),
+                          value: controller.isSendSms.value,
+                          onChanged: controller.updateSms,
+                        )),
                   ),
                 ],
               ),
             ),
-            if (controller.isDeleting.value)
+            if (controller.isDeleting.value || controller.isUpdatingSms.value)
               const Center(child: CircularProgressIndicator()),
           ],
         );


### PR DESCRIPTION
## Summary
- add `isSendSms` flag to `Party` model with persistence
- allow enabling/disabling SMS notifier when adding or editing a party
- move party profile edit/delete actions to app bar menu and add SMS toggle

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e18fed8c833093cb93d453ec8687