### PR TITLE
Use AppDateFormatter across case screens

### DIFF
--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -7,6 +7,7 @@ import '../../../constants/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:panara_dialogs/panara_dialogs.dart';
+import '../../../utils/app_date_formatter.dart';
 
 import '../controllers/add_case_controller.dart';
 import '../../../models/party.dart';
@@ -197,12 +198,8 @@ class AddCaseScreen extends StatelessWidget {
                           visualDensity: VisualDensity.compact,
                           contentPadding:
                               const EdgeInsets.symmetric(horizontal: 12),
-                          title: Text(controller.filedDate.value == null
-                              ? 'Filed Date'
-                              : controller.filedDate.value
-                                  .toString()
-                                  .split(' ')
-                                  .first),
+                          title: Text(controller.filedDate.value?.formattedDate ??
+                              'Filed Date'),
                           trailing:
                               const Icon(HugeIcons.strokeRoundedCalendar01),
                           onTap: () async {
@@ -249,12 +246,8 @@ class AddCaseScreen extends StatelessWidget {
                           visualDensity: VisualDensity.compact,
                           contentPadding:
                               const EdgeInsets.symmetric(horizontal: 12),
-                          title: Text(controller.hearingDate.value == null
-                              ? 'Hearing Date'
-                              : controller.hearingDate.value
-                                  .toString()
-                                  .split(' ')
-                                  .first),
+                          title: Text(controller.hearingDate.value?.formattedDate ??
+                              'Hearing Date'),
                           trailing:
                               const Icon(HugeIcons.strokeRoundedCalendar01),
                           onTap: () async {

--- a/lib/modules/case/screens/case_detail_screen.dart
+++ b/lib/modules/case/screens/case_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:panara_dialogs/panara_dialogs.dart';
 import '../../../models/court_case.dart';
 import '../../../widgets/app_info_row.dart';
 import '../../../utils/activation_guard.dart';
+import '../../../utils/app_date_formatter.dart';
 import '../../../services/app_firebase.dart';
 import '../services/case_service.dart';
 import '../controllers/case_controller.dart';
@@ -16,11 +17,6 @@ class CaseDetailScreen extends StatelessWidget {
 
   final CourtCase caseItem;
   final RxBool isDeleting = false.obs;
-
-  String _fmtDate(Timestamp ts) {
-    final d = ts.toDate();
-    return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -242,7 +238,8 @@ class CaseDetailScreen extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           appInfoRow(
-                              'Filed Date', _fmtDate(caseItem.filedDate)),
+                              'Filed Date',
+                              caseItem.filedDate.toDate().formattedDate),
                           const SizedBox(height: 12),
                           Row(
                             children: [
@@ -319,10 +316,10 @@ class CaseDetailScreen extends StatelessWidget {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text('Last: '
-                                    '${last != null ? _fmtDate(last) : '-'}'),
+                                    '${last != null ? last.toDate().formattedDate : '-'}'),
                                 const SizedBox(height: 6),
                                 Text('Next: '
-                                    '${next != null ? _fmtDate(next) : '-'}'),
+                                    '${next != null ? next.toDate().formattedDate : '-'}'),
                               ],
                             );
                           }),

--- a/lib/modules/case/screens/edit_case_screen.dart
+++ b/lib/modules/case/screens/edit_case_screen.dart
@@ -6,6 +6,7 @@ import '../../../widgets/app_text_from_field.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:panara_dialogs/panara_dialogs.dart';
+import '../../../utils/app_date_formatter.dart';
 
 import '../../../models/court_case.dart';
 import '../../../models/party.dart';
@@ -133,12 +134,8 @@ class EditCaseScreen extends StatelessWidget {
                       isMaxLines: 3,
                     ),
                     Obx(() => ListTile(
-                          title: Text(controller.filedDate.value == null
-                              ? 'Filed Date'
-                              : controller.filedDate.value
-                                  .toString()
-                                  .split(' ')
-                                  .first),
+                          title: Text(controller.filedDate.value?.formattedDate ??
+                              'Filed Date'),
                           trailing:
                               const Icon(HugeIcons.strokeRoundedCalendar01),
                           onTap: () async {
@@ -181,12 +178,8 @@ class EditCaseScreen extends StatelessWidget {
                   spacing: 10,
                   children: [
                     Obx(() => ListTile(
-                          title: Text(controller.hearingDate.value == null
-                              ? 'Hearing Date'
-                              : controller.hearingDate.value
-                                  .toString()
-                                  .split(' ')
-                                  .first),
+                          title: Text(controller.hearingDate.value?.formattedDate ??
+                              'Hearing Date'),
                           trailing:
                               const Icon(HugeIcons.strokeRoundedCalendar01),
                           onTap: () async {


### PR DESCRIPTION
## Summary
- Format filed and hearing dates in AddCaseScreen using `AppDateFormatter`
- Apply `AppDateFormatter` in EditCaseScreen for consistent date display
- Replace custom timestamp formatter in CaseDetailScreen with `AppDateFormatter`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89f4e0a988330ad3a1903e92b436d