### PR TITLE
Add trial dialog with navigation to Add Party

### DIFF
--- a/lib/utils/new_user_dailog.dart
+++ b/lib/utils/new_user_dailog.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import '../modules/layout/screens/layout_screen.dart';
+import '../modules/party/screens/add_party_screen.dart';
+
 void showNewUserDialog() {
   Future.delayed(const Duration(seconds: 5), () {
     if (Get.context != null) {
@@ -9,30 +12,38 @@ void showNewUserDialog() {
           shape:
               RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           child: Padding(
-            padding: const EdgeInsets.all(20),
+            padding: const EdgeInsets.all(24),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(Icons.celebration, size: 50, color: Colors.green),
+                Icon(Icons.card_giftcard, size: 60, color: Colors.teal),
                 const SizedBox(height: 16),
                 const Text(
-                  "Welcome 🎉",
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  'অভিনন্দন!',
+                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
                 ),
-                const SizedBox(height: 10),
+                const SizedBox(height: 12),
                 const Text(
-                  "Your account has been created successfully!",
+                  'আপনি ৩০ দিনের ফ্রি ট্রায়েল পেয়েছেন।\n'
+                  'Court Diary এর সকল ফিচার ব্যবহার করে দেখুন।',
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 16),
+                  style: TextStyle(fontSize: 16, height: 1.4),
                 ),
-                const SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () => Get.back(),
-                  style: ElevatedButton.styleFrom(
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8)),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      await Get.offAll(() => const LayoutScreen());
+                      Get.to(() => const AddPartyScreen(),
+                          fullscreenDialog: true);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8)),
+                    ),
+                    child: const Text('ব্যবহার শুরু করুন'),
                   ),
-                  child: const Text("Got it"),
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- enhance new user dialog to highlight 30-day free trial
- add start button that sends user directly to Add Party screen

## Testing
- `dart format lib/utils/new_user_dailog.dart` *(fails: command not found)*
- `flutter format lib/utils/new_user_dailog.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a19bf59083308ba2228ba7818b64