### PR TITLE
feat: add searchable party selector

### DIFF
--- a/lib/modules/case/screens/add_case_screen.dart
+++ b/lib/modules/case/screens/add_case_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:panara_dialogs/panara_dialogs.dart';
 import '../../../utils/app_date_formatter.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+import '../../../local_library/text_from_field_wraper.dart';
 
 import '../controllers/add_case_controller.dart';
 import '../../../models/party.dart';
@@ -103,45 +105,51 @@ class AddCaseScreen extends StatelessWidget {
       required String hint,
       required IconData icon,
     }) {
-      return Obx(() => DropdownButtonFormField<Party>(
-            value: selected.value,
-            isExpanded: true,
-            borderRadius: BorderRadius.circular(12),
-            menuMaxHeight: 320,
-            icon: const Icon(Icons.keyboard_arrow_down_rounded),
-            decoration: InputDecoration(
-              labelText: label,
-              hintText: hint,
-              prefixIcon: Icon(icon),
-              filled: true,
-              fillColor: Theme.of(context).colorScheme.surface.withOpacity(0.7),
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.outlineVariant,
+      final textController = TextEditingController();
+      return Obx(() {
+        final cs = Theme.of(context).colorScheme;
+        if (selected.value != null &&
+            textController.text != selected.value!.name) {
+          textController.text = selected.value!.name;
+        }
+        return TextFormFieldWrapper(
+          borderFocusedColor: cs.primary,
+          formField: TypeAheadField<Party>(
+            controller: textController,
+            builder: (context, textEditingController, focusNode) {
+              return TextField(
+                controller: textEditingController,
+                focusNode: focusNode,
+                cursorColor: cs.onSurface,
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  labelText: label,
+                  hintText: hint,
+                  prefixIcon: Icon(icon, color: cs.onSurfaceVariant),
                 ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.primary,
-                  width: 1.4,
-                ),
-              ),
-            ),
-            items: controller.parties
-                .map((p) => DropdownMenuItem(
-                      value: p,
-                      child: Text(p.name),
-                    ))
-                .toList(),
-            onChanged: (v) => selected.value = v,
-          ));
+                onChanged: (_) => selected.value = null,
+              );
+            },
+            suggestionsCallback: (pattern) {
+              final query = pattern.toLowerCase();
+              return controller.parties.where((p) {
+                return p.name.toLowerCase().contains(query) ||
+                    p.phone.contains(pattern);
+              }).toList();
+            },
+            itemBuilder: (context, Party party) {
+              return ListTile(
+                title: Text(party.name),
+                subtitle: Text(party.phone),
+              );
+            },
+            onSelected: (Party party) {
+              selected.value = party;
+              textController.text = party.name;
+            },
+          ),
+        );
+      });
     }
 
     return Scaffold(


### PR DESCRIPTION
## Summary
- replace party dropdown with search-based typeahead in add/edit case screens
- filter parties by name or phone and update selected party

## Testing
- `dart format lib/modules/case/screens/add_case_screen.dart lib/modules/case/screens/edit_case_screen.dart` *(failed: command not found)*
- `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90a241f988330a3757428f1af7c1b